### PR TITLE
Fixing leak with eventEmitter

### DIFF
--- a/src/server/app/messages/sockets/message.server.socket.js
+++ b/src/server/app/messages/sockets/message.server.socket.js
@@ -48,7 +48,7 @@ MessageSocket.prototype.getTopic = function(userId) {
 MessageSocket.prototype.disconnect = function() {
 	logger.info('MessageSocket: Disconnected from client.');
 
-	clearInterval(this.intervalId);
+	this.unsubscribe(this.getTopic());
 
 };
 
@@ -58,7 +58,7 @@ MessageSocket.prototype.disconnect = function() {
 MessageSocket.prototype.error = function(err) {
 	logger.error(err, 'MessageSocket: Client connection error');
 
-	clearInterval(this.intervalId);
+	this.unsubscribe(this.getTopic());
 };
 
 /**

--- a/src/server/app/util/sockets/event.server.socket.js
+++ b/src/server/app/util/sockets/event.server.socket.js
@@ -142,11 +142,13 @@ EventSocket.prototype.subscribe = function(eventName) {
 	}
 
 	// Simple throttling is done here, if enabled
+
 	if (this._emitRateMs > 0) {
-		eventEmitter.getEventEmitter().on(eventName, _.throttle(this.socketPayloadHandler, this._emitRateMs).bind(this, eventName));
+		this.emitterFunc = _.throttle(this.socketPayloadHandler, this._emitRateMs).bind(this, eventName);
 	} else {
-		eventEmitter.getEventEmitter().on(eventName, this.socketPayloadHandler.bind(this, eventName));
+		this.emitterFunc = this.socketPayloadHandler.bind(this, eventName);
 	}
+	eventEmitter.getEventEmitter().on(eventName, this.emitterFunc);
 };
 
 /**
@@ -154,8 +156,8 @@ EventSocket.prototype.subscribe = function(eventName) {
  *
  * @param {string} topic The topic to unsubscribe from (optional).
  */
-EventSocket.prototype.unsubscribe = function() {
-
+EventSocket.prototype.unsubscribe = function(eventName) {
+	eventEmitter.getEventEmitter().removeListener(eventName, this.emitterFunc);
 };
 
 EventSocket.prototype.socketPayloadHandler = function(eventName, message) {


### PR DESCRIPTION
eventEmitters had a leak in that they were not properly cleaned up when client sockets disconnected.

Please note this a good reminder that the event sockets are really intended for local development or very lightweight deployments.  The eventEmitter by default will only support 10 sockets at once.
