### PR TITLE
Start navbar in collapsed mode when loading small pages.

### DIFF
--- a/src/client/app/core/core.component.ts
+++ b/src/client/app/core/core.component.ts
@@ -8,7 +8,7 @@ export class CoreComponent {
 	protected banner: any;
 	protected copyright: string;
 	protected pki: boolean;
-	protected collapsed: boolean = false;
+	protected collapsed: boolean = true;
 
 	protected user: User;
 


### PR DESCRIPTION
Currently, the navbar is open when loading on mobile devices. This causes the main page elements to be hidden from the user unless they collapse the navbar.

This PR will reverse that behavior, allowing the user to see the main part of the screen on page load, and then allowing them to expand the navbar menu if needed.