### PR TITLE
Initial work for adding an api document to mean2-starter

### DIFF
--- a/config/env/default.js
+++ b/config/env/default.js
@@ -292,6 +292,18 @@ module.exports = {
 		sms: false
 	},
 
-	urlHandler: 'default'
+	urlHandler: 'default',
 
+	showApi: true,
+
+	apiConfig: {
+		info: {
+			title: 'MEAN2 REST API',
+			version: '1.0.0',
+			description: 'This is a REST API for the MEAN2 starter app.',
+			contact: {
+				email: 'reblace@asymmetrik.com'
+			}
+		}
+	}
 };

--- a/config/env/default.js
+++ b/config/env/default.js
@@ -295,7 +295,7 @@ module.exports = {
 	urlHandler: 'default',
 
 	/*
-	 * Boolean for whether or not the API Docs will be available
+	 * API Documentation settings
 	 */
 	apiDocs: {
 		enabled: false,

--- a/config/env/default.js
+++ b/config/env/default.js
@@ -294,16 +294,12 @@ module.exports = {
 
 	urlHandler: 'default',
 
-	showApi: false,
-
-	apiConfig: {
-		info: {
-			title: 'MEAN2 REST API',
-			version: '1.0.0',
-			description: 'This is a REST API for the MEAN2 starter app.',
-			contact: {
-				email: 'reblace@asymmetrik.com'
-			}
-		}
+	/*
+	 * Boolean for whether or not the API Docs will be available
+	 */
+	apiDocs: {
+		enabled: false,
+		url: '/api-docs'
 	}
+
 };

--- a/config/env/default.js
+++ b/config/env/default.js
@@ -294,7 +294,7 @@ module.exports = {
 
 	urlHandler: 'default',
 
-	showApi: true,
+	showApi: false,
 
 	apiConfig: {
 		info: {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
 		"q": "1.4",
 		"serve-favicon": "2.3",
 		"socket.io": "1.5",
+		"swagger-jsdoc": "1.8.3",
+		"swagger-ui-express": "1.0.2",
 		"through2": "2.0",
 		"validator": "6.1",
 

--- a/src/server/app/admin/routes/eua.server.routes.js
+++ b/src/server/app/admin/routes/eua.server.routes.js
@@ -11,20 +11,125 @@ module.exports = function(app) {
 	 * End User Agreement Routes
 	 */
 
+	/**
+	 * @swagger
+	 * /messages:
+	 *   post:
+	 *     tags: [eua]
+	 *     description: Search for eaus with a specific property value.
+	 *     parameters:
+	 *     - in: body
+	 *       name: body
+	 *       required: true
+	 *       schema:
+	 *         type: object
+	 *         required: [s]
+	 *         properties:
+	 *           q:
+	 *             type: object
+	 *           s:
+	 *             type: string
+	 *     - in: query
+	 *       name: page
+	 *       type: integer
+	 *     - in: query
+	 *       name: size
+	 *       type: integer
+	 *     - in: query
+	 *       name: sort
+	 *       type: string
+	 *     - in: query
+	 *       name: dir
+	 *       type: string
+	 *       enum: [ASC, DESC]
+	 */
 	app.route('/euas')
 		.post(users.hasAdminAccess, users.searchEuas);
 
+	/**
+	 * @swagger
+	 * /eua/accept:
+	 *   post:
+	 *     tags: [eua]
+	 *     description: Lets the current user accept the eua.
+	 */
 	app.route('/eua/accept')
 		.post(users.has(users.requiresLogin), users.acceptEua);
 
+	/**
+	 * @swagger
+	 * /eua/{euaId}/publish:
+	 *   post:
+	 *     tags: [eua]
+	 *     description: Lets the current user accept the eua.
+	 *     parameters:
+	 *     - in: path
+	 *       name: euaId
+	 *       required: true
+	 *       type: string
+	 *     - in: body
+	 *       name: body
+	 *       required: true
+	 *       schema:
+	 *         $ref: '#/definitions/EuaDto'
+	 */
 	app.route('/eua/:euaId/publish')
 		.post(users.hasAdminAccess, users.publishEua);
 
+	/**
+	 * @swagger
+	 * /eua/{euaId}:
+	 *   get:
+	 *     tags: [eua]
+	 *     description: Returns the eua with given eua id.
+	 *     parameters:
+	 *     - in: path
+	 *       name: euaId
+	 *       type: string
+	 *       required: true
+	 *   post:
+	 *     tags: [eua]
+	 *     description: Updates the eua's information with the given eua id.
+	 *     parameters:
+	 *     - in: path
+	 *       name: euaId
+	 *       type: string
+	 *       required: true
+	 *     - name: body
+	 *       in: body
+	 *       required: true
+	 *       schema:
+	 *         $ref: '#/definitions/EuaDto'
+	 *   delete:
+	 *     tags: [eua]
+	 *     description: Deletes the message with the given eua id.
+	 *     parameters:
+	 *     - in: path
+	 *       name: euaId
+	 *       type: string
+	 *       required: true
+	 */
 	app.route('/eua/:euaId')
 		.get(   users.hasAdminAccess, users.getEuaById)
 		.post(  users.hasAdminAccess, users.updateEua)
 		.delete(users.hasAdminAccess, users.deleteEua);
 
+	/**
+	 * @swagger
+	 * /eua:
+	 *   get:
+	 *     tags: [eua]
+	 *     description: Gets the user's current eua.
+	 *   post:
+	 *     tags: [eua]
+	 *     description: Creates an eua for the current user.
+	 *     parameters:
+	 *     - in: body
+	 *       name: body
+	 *       required: true
+	 *       schema:
+	 *         $ref: '#/definitions/EuaDto'
+	 */
 	app.route('/eua')
 		.get( users.has(users.requiresLogin), users.getCurrentEua)
 		.post(users.hasAdminAccess, users.createEua);
@@ -33,3 +138,16 @@ module.exports = function(app) {
 	app.param('euaId', users.euaById);
 
 };
+
+/**
+ * @swagger
+ * definitions:
+ *   EuaDto:
+ *     type: object
+ *     required: [title, body]
+ *     properties:
+ *       title:
+ *         type: string
+ *       text:
+ *         type: string
+ */

--- a/src/server/app/admin/routes/eua.server.routes.js
+++ b/src/server/app/admin/routes/eua.server.routes.js
@@ -13,10 +13,10 @@ module.exports = function(app) {
 
 	/**
 	 * @swagger
-	 * /messages:
+	 * /euas:
 	 *   post:
 	 *     tags: [eua]
-	 *     description: Search for eaus with a specific property value.
+	 *     description: Search for euas with a specific word in the title or text.
 	 *     parameters:
 	 *     - in: body
 	 *       name: body
@@ -67,11 +67,6 @@ module.exports = function(app) {
 	 *       name: euaId
 	 *       required: true
 	 *       type: string
-	 *     - in: body
-	 *       name: body
-	 *       required: true
-	 *       schema:
-	 *         $ref: '#/definitions/EuaDto'
 	 */
 	app.route('/eua/:euaId/publish')
 		.post(users.hasAdminAccess, users.publishEua);

--- a/src/server/app/admin/routes/users.server.routes.js
+++ b/src/server/app/admin/routes/users.server.routes.js
@@ -289,7 +289,20 @@ module.exports = function(app) {
 
 		logger.info('Configuring local user authentication routes.');
 
-		// Admin Create User
+		/**
+		 * @swagger
+	 	 * /admin/user:
+	 	 *   strategy: local
+	 	 *   post:
+	 	 *     tags: [auth]
+	 	 *     description: Creates a new user.
+	 	 *     parameters:
+	 	 *     - in: body
+	 	 *       name: body
+	 	 *       required: true
+	 	 *       schema:
+	 	 *         $ref: '#/definitions/AdminUpdateUserDto'
+	 	 */
 		app.route('/admin/user')
 			.post(users.hasAdminAccess, users.adminCreateUser);
 

--- a/src/server/app/admin/routes/users.server.routes.js
+++ b/src/server/app/admin/routes/users.server.routes.js
@@ -257,7 +257,28 @@ module.exports = function(app) {
 	/**
 	 * Auth-specific routes
 	 */
+
+	/**
+	 * @swagger
+	 * /auth/signin:
+	 *   post:
+	 *     tags: [auth]
+	 *     description: Signs into the application.
+	 *     parameters:
+	 *     - in: body
+	 *       name: body
+	 *       type: object
+	 *       description: Local or proxy-pki config
+	 */
 	app.route('/auth/signin').post(users.signin);
+
+	/**
+	 * @swagger
+	 * /auth/signout:
+	 *   get:
+	 *     tags: [auth]
+	 *     description: Signs out of the application.
+	 */
 	app.route('/auth/signout')
 		.get(users.has(users.requiresLogin), users.signout);
 

--- a/src/server/app/admin/routes/users.server.routes.js
+++ b/src/server/app/admin/routes/users.server.routes.js
@@ -9,34 +9,139 @@ var
 
 	users = require(path.resolve('./src/server/app/admin/controllers/users.server.controller.js'));
 
-
 module.exports = function(app) {
-
 	/**
 	 * User Routes (don't require admin)
 	 */
 
-	// Self-service user routes
+	/**
+	 * @swagger
+	 * /user/me:
+	 *   get:
+	 *     tags: [user]
+	 *     description: Returns the current user.
+	 *   post:
+	 *     tags: [user]
+	 *     desciption: Allows a user to update their new information. If "password" is updated, "currentPassword" must be included.
+	 *     parameters:
+	 *     - name: body
+	 *       in: body
+	 *       required: true
+	 *       schema:
+	 *         $ref: '#/definitions/UpdateUserDto'
+	 */
 	app.route('/user/me')
 		.get( users.has(users.requiresLogin), users.getCurrentUser)
 		.post(users.has(users.requiresLogin), users.updateCurrentUser);
 
-	// User getting another user's info
+	/**
+	 * @swagger
+	 * /user/{userId}:
+	 *   get:
+	 *     tags: [user]
+	 *     description: Returns the user with the given userId (filtered view).
+	 *     parameters:
+	 *     - in: path
+	 *       required: true
+	 *       name: userId
+	 *       type: string
+	 */
 	app.route('/user/:userId')
 		.get(users.hasAccess, users.getUserById);
 
-	// User searching for other users
+	/**
+	 * @swagger
+	 * /users:
+	 *   post:
+	 *     tags: [user]
+	 *     description: Search for users with a specific property value.
+	 *     parameters:
+	 *     - in: body
+	 *       name: body
+	 *       required: true
+	 *       schema:
+	 *         $ref: '#/definitions/QueryAndSearchBody'
+	 *     - in: query
+	 *       name: page
+	 *       type: integer
+	 *     - in: query
+	 *       name: size
+	 *       type: integer
+	 *     - in: query
+	 *       name: sort
+	 *       type: string
+	 *     - in: query
+	 *       name: dir
+	 *       type: string
+	 *       enum: [ASC, DESC]
+	 */
 	app.route('/users')
 		.post(users.hasAccess, users.searchUsers);
 
-	// User match-based search for other users (this searches based on a fragment)
+	/**
+	 * @swagger
+	 * /users/match:
+	 *   post:
+	 *     tags: [user]
+	 *     description: Search for users with a specific fragment as part of one of its property values.
+	 *     parameters:
+	 *     - in: body
+	 *       name: body
+	 *       required: true
+	 *       schema:
+	 *         $ref: '#/definitions/QueryAndSearchBody'
+	 *     - in: query
+	 *       name: page
+	 *       type: integer
+	 *     - in: query
+	 *       name: size
+	 *       type: integer
+	 *     - in: query
+	 *       name: sort
+	 *       type: string
+	 *     - in: query
+	 *       name: dir
+	 *       type: string
+	 *       enum: [ASC, DESC]
+	 */
 	app.route('/users/match')
 		.post(users.hasAccess, users.matchUsers);
 
 	/**
-	 * Notification Preferences Routes
+	 * @swagger
+	 * /users/me/preferences/notifications/{notificationType}/{referenceId}:
+	 *   get:
+	 *     tags: [user]
+	 *     description: Retrieves current user's notification preferences by type and id.
+	 *     parameters:
+	 *     - in: path
+	 *       name: notificationType
+	 *       type: string
+	 *       enum: []
+	 *     - in: path
+	 *       name: referenceId
+	 *       type: string
+	 *   post:
+	 *     tags: [user]
+	 *     description: Update current user's notification preferences by type and id.
+	 *     parameters:
+	 *     - in: path
+	 *       name: notificationType
+	 *       type: string
+	 *       enum: []
+	 *     - in: path
+	 *       name: referenceId
+	 *       type: string
+	 *     - in: body
+	 *       name: body
+	 *       schema:
+	 *         type: object
+	 *         properties:
+	 *           email:
+	 *             type: boolean
+	 *           sms:
+	 *             type: boolean
 	 */
-
 	app.route('/users/me/preferences/notifications/:notificationType/:referenceId')
 		.get(users.hasAccess, users.getNotificationPreferencesByTypeAndId)
 		.post(users.hasAccess, users.setNotificationPreferencesByTypeAndId);
@@ -45,21 +150,107 @@ module.exports = function(app) {
 	 * Admin User Routes (requires admin)
 	 */
 
-	// Admin retrieve/update/delete
+	/**
+	 * @swagger
+	 * /admin/user/{userId}:
+	 *   get:
+	 *     tags: [user]
+	 *     description: Returns the user with the given user id (full view).
+	 *     parameters:
+	 *     - in: path
+	 *       required: true
+	 *       name: userId
+	 *       type: string
+	 *   post:
+	 *     tags: [user]
+	 *     description: Updates the user's user information with the given user id.
+	 *     parameters:
+	 *     - in: path
+	 *       required: true
+	 *       name: userId
+	 *       type: string
+	 *     - name: body
+	 *       in: body
+	 *       required: true
+	 *       schema:
+	 *         $ref: '#/definitions/AdminUpdateUserDto'
+	 *   delete:
+	 *     tags: [user]
+	 *     description: Deletes the user with the given user id.
+	 *     parameters:
+	 *     - in: path
+	 *       required: true
+	 *       name: userId
+	 *       type: string
+	 */
 	app.route('/admin/user/:userId')
 		.get(   users.hasAdminAccess, users.adminGetUser)
 		.post(  users.hasAdminAccess, users.adminUpdateUser)
 		.delete(users.hasAdminAccess, users.adminDeleteUser);
 
-	// Admin search users
+	/**
+	 * @swagger
+	 * /admin/users:
+	 *   post:
+	 *     tags: [user]
+	 *     description: Search for users with a specific property value.
+	 *     parameters:
+	 *     - in: body
+	 *       name: body
+	 *       schema:
+	 *         $ref: '#/definitions/QueryAndSearchBody'
+	 *     - in: query
+	 *       name: page
+	 *       type: number
+	 *     - in: query
+	 *       name: size
+	 *       type: number
+	 *     - in: query
+	 *       name: sort
+	 *       type: string
+	 *     - in: query
+	 *       name: dir
+	 *       type: string
+	 *       enum: [ASC, DESC]
+	 */
 	app.route('/admin/users')
 		.post(users.hasAdminAccess, users.adminSearchUsers);
 
-	// Get user CSV using the specifies config id
+	/**
+	 * @swagger
+	 * /admin/users/csv/{exportId}:
+	 *   get:
+	 *     tags: [user]
+	 *     description: Returns user CSV using the specified config id.
+	 *     parameters:
+	 *     - in: path
+	 *       name: exportId
+	 *       description: exportId
+	 *       required: true
+	 *       type: string
+	 */
 	app.route('/admin/users/csv/:exportId')
 		.get(users.hasAdminAccess, users.adminGetCSV);
 
-	// Admin retrieving a User field for all users in the system
+	/**
+	 * @swagger
+	 * /admin/users/getAll:
+	 *   post:
+	 *     tags: [user]
+	 *     description: Retrieve the supplied field from all users.
+	 *     parameters:
+	 *     - in: body
+	 *       name: body
+	 *       required: true
+	 *       schema:
+	 *         type: object
+	 *         required: [field]
+	 *         properties:
+	 *           field:
+	 *             type: string
+	 *           query:
+	 *             type: object
+	 */
 	app.route('/admin/users/getAll')
 		.post(users.hasAdminAccess, users.adminGetAll);
 
@@ -108,3 +299,38 @@ module.exports = function(app) {
 	// Finish by binding the user middleware
 	app.param('userId', users.userById);
 };
+
+// Swagger Definitions
+
+/**
+ * @swagger
+ * definitions:
+ *   AdminUpdateUserDto:
+ *     type: object
+ *     required: [name, organization, username, email]
+ *     properties:
+ *       name:
+ *         type: string
+ *       organization:
+ *         type: string
+ *       username:
+ *         type: string
+ *       email:
+ *         type: string
+ *       password:
+ *         type: string
+ *   NonAdminUpdateUserDto:
+ *     allOf:
+ *     - $ref: '#/definitions/AdminUpdateUserDto'
+ *     - properties:
+ *         currentPassword:
+ *           type: string
+ *   QueryAndSearchBody:
+ *     type: object
+ *     required: [s]
+ *     properties:
+ *       q:
+ *         type: object
+ *       s:
+ *         type: string
+ */

--- a/src/server/app/admin/routes/users.server.routes.js
+++ b/src/server/app/admin/routes/users.server.routes.js
@@ -54,7 +54,7 @@ module.exports = function(app) {
 	 * /users:
 	 *   post:
 	 *     tags: [user]
-	 *     description: Search for users with a specific property value.
+	 *     description: Search for users with a specific word in the username, name, or email.
 	 *     parameters:
 	 *     - in: body
 	 *       name: body
@@ -83,7 +83,7 @@ module.exports = function(app) {
 	 * /users/match:
 	 *   post:
 	 *     tags: [user]
-	 *     description: Search for users with a specific fragment as part of one of its property values.
+	 *     description: Search for users with a fragment in the username, name, or email.
 	 *     parameters:
 	 *     - in: body
 	 *       name: body

--- a/src/server/app/audit/routes/audit.server.routes.js
+++ b/src/server/app/audit/routes/audit.server.routes.js
@@ -7,10 +7,52 @@ let path = require('path'),
 
 module.exports = function(app) {
 
+	/**
+	 * @swagger
+	 * /audit:
+	 *   post:
+	 *     tags: [audit]
+	 *     description: Search for audits with a specific property value.
+	 *     parameters:
+	 *     - in: body
+	 *       name: body
+	 *       required: true
+	 *       schema:
+	 *         type: object
+	 *         required: [s]
+	 *         properties:
+	 *           q:
+	 *             type: object
+	 *           s:
+	 *             type: string
+	 *     - in: query
+	 *       name: page
+	 *       type: integer
+	 *     - in: query
+	 *       name: size
+	 *       type: integer
+	 *     - in: query
+	 *       name: sort
+	 *       type: string
+	 *     - in: query
+	 *       name: dir
+	 *       type: string
+	 *       enum: [ASC, DESC]
+	 */
 	app.route('/audit')
 		.post(users.hasAuditorAccess, auditController.search);
 
+	/**
+	 * @swagger
+	 * /audit/distinctValues:
+	 *   get:
+	 *     tags: [audit]
+	 *     description: Retrieves the distinct values for a field in the audit collection.
+	 *     parameters:
+	 *     - in: query
+	 *       name: field
+	 *       type: string
+	 */
 	app.route('/audit/distinctValues')
 		.get(users.hasAuditorAccess, auditController.getDistinctValues);
-
 };

--- a/src/server/app/audit/routes/audit.server.routes.js
+++ b/src/server/app/audit/routes/audit.server.routes.js
@@ -12,7 +12,7 @@ module.exports = function(app) {
 	 * /audit:
 	 *   post:
 	 *     tags: [audit]
-	 *     description: Search for audits with a specific property value.
+	 *     description: Search for messages with a specific word in the message, action, auditType or object.
 	 *     parameters:
 	 *     - in: body
 	 *       name: body

--- a/src/server/app/messages/routes/messages.server.routes.js
+++ b/src/server/app/messages/routes/messages.server.routes.js
@@ -6,15 +6,91 @@ var	path = require('path'),
 
 module.exports = function(app) {
 
-	// Create Message
+	/**
+	 * @swagger
+	 * /admin/message:
+	 *   post:
+	 *     tags: [message]
+	 *     description: Creates a message.
+	 *     required: true
+	 *     parameters:
+	 *     - in: body
+	 *       name: body
+	 *       required: true
+	 *       schema:
+	 *         $ref: '#/definitions/MessageDto'
+	 */
 	app.route('/admin/message')
 		.post(users.hasAdminAccess, messages.create);
 
-	// Search messages
+	/**
+	 * @swagger
+	 * /messages:
+	 *   post:
+	 *     tags: [message]
+	 *     description: Search for messages with a specific property value.
+	 *     parameters:
+	 *     - in: body
+	 *       name: body
+	 *       required: true
+	 *       schema:
+	 *         type: object
+	 *         required: [s]
+	 *         properties:
+	 *           q:
+	 *             type: object
+	 *           s:
+	 *             type: string
+	 *     - in: query
+	 *       name: page
+	 *       type: integer
+	 *     - in: query
+	 *       name: size
+	 *       type: integer
+	 *     - in: query
+	 *       name: sort
+	 *       type: string
+	 *     - in: query
+	 *       name: dir
+	 *       type: string
+	 *       enum: [ASC, DESC]
+	 */
 	app.route('/messages')
 		.post(users.hasAccess, messages.search);
 
-	// Admin retrieve/update/delete
+	/**
+	 * @swagger
+	 * /admin/message/{msgId}:
+	 *   get:
+	 *     tags: [message]
+	 *     description: Returns the message with given message id.
+	 *     parameters:
+	 *     - in: path
+	 *       name: msgId
+	 *       type: string
+	 *       required: true
+	 *   post:
+	 *     tags: [message]
+	 *     description: Updates the message's information with the given message id.
+	 *     parameters:
+	 *     - in: path
+	 *       name: msgId
+	 *       type: string
+	 *       required: true
+	 *     - name: body
+	 *       in: body
+	 *       required: true
+	 *       schema:
+	 *         $ref: '#/definitions/MessageDto'
+	 *   delete:
+	 *     tags: [message]
+	 *     description: Deletes the message with the given message id.
+	 *     parameters:
+	 *     - in: path
+	 *       name: msgId
+	 *       type: string
+	 *       required: true
+	 */
 	app.route('/admin/message/:msgId')
 		.get(   users.hasAccess, messages.read)
 		.post(  users.hasAdminAccess, messages.update)
@@ -23,3 +99,26 @@ module.exports = function(app) {
 	// Bind the message middleware
 	app.param('msgId', messages.messageById);
 };
+
+// Swagger Definitions
+
+/**
+ * @swagger
+ * definitions:
+ *   MessageDto:
+ *     type: object
+ *     required: [title, body]
+ *     properties:
+ *       title:
+ *         type: string
+ *         example: Sample Title
+ *       tearline:
+ *         type: string
+ *         example: Sample Tear Line
+ *       body:
+ *         type: string
+ *         example: Sample Body
+ *       type:
+ *         type: string
+ *         enum: [MOTD, INFO, WARN, ERROR]
+ */

--- a/src/server/app/messages/routes/messages.server.routes.js
+++ b/src/server/app/messages/routes/messages.server.routes.js
@@ -12,7 +12,6 @@ module.exports = function(app) {
 	 *   post:
 	 *     tags: [message]
 	 *     description: Creates a message.
-	 *     required: true
 	 *     parameters:
 	 *     - in: body
 	 *       name: body
@@ -28,7 +27,7 @@ module.exports = function(app) {
 	 * /messages:
 	 *   post:
 	 *     tags: [message]
-	 *     description: Search for messages with a specific property value.
+	 *     description: Search for messages with a specific word in the title, tearline, or type.
 	 *     parameters:
 	 *     - in: body
 	 *       name: body

--- a/src/server/app/teams/routes/tags.server.routes.js
+++ b/src/server/app/teams/routes/tags.server.routes.js
@@ -11,12 +11,90 @@ module.exports = function(app) {
 	 * Tag Routes
 	 */
 
+	/**
+	 * @swagger
+	 * /tag:
+	 *   put:
+	 *     tags: [tag]
+	 *     description: Creates a tag.
+	 *     parameters:
+	 *     - in: body
+	 *       name: body
+	 *       required: true
+	 *       schema:
+	 *         $ref: '#/definitions/TagDto'
+	 */
 	app.route('/tag')
 		.put(users.hasAccess, users.hasAny(users.requiresAdminRole, tags.requiresEditor), tags.create);
 
+	/**
+	 * @swagger
+	 * /tags:
+	 *   post:
+	 *     tags: [tag]
+	 *     description: Search for tags with a specific word in the name or description.
+	 *     parameters:
+	 *     - in: body
+	 *       name: body
+	 *       required: true
+	 *       schema:
+	 *         type: object
+	 *         required: [s]
+	 *         properties:
+	 *           q:
+	 *             type: object
+	 *           s:
+	 *             type: string
+	 *     - in: query
+	 *       name: page
+	 *       type: integer
+	 *     - in: query
+	 *       name: size
+	 *       type: integer
+	 *     - in: query
+	 *       name: sort
+	 *       type: string
+	 *     - in: query
+	 *       name: dir
+	 *       type: string
+	 *       enum: [ASC, DESC]
+	 */
 	app.route('/tags')
 		.post(users.hasAccess, tags.search);
 
+	/**
+	 * @swagger
+	 * /admin/tag/{tagId}:
+	 *   get:
+	 *     tags: [tag]
+	 *     description: Returns the tag with given tag id.
+	 *     parameters:
+	 *     - in: path
+	 *       name: tagId
+	 *       type: string
+	 *       required: true
+	 *   post:
+	 *     tags: [tag]
+	 *     description: Updates the tag's information with the given tag id.
+	 *     parameters:
+	 *     - in: path
+	 *       name: tagId
+	 *       type: string
+	 *       required: true
+	 *     - name: body
+	 *       in: body
+	 *       required: true
+	 *       schema:
+	 *         $ref: '#/definitions/TagDto'
+	 *   delete:
+	 *     tags: [tag]
+	 *     description: Deletes the tag with the given tag id.
+	 *     parameters:
+	 *     - in: path
+	 *       name: tagId
+	 *       type: string
+	 *       required: true
+	 */
 	app.route('/tag/:tagId')
 		.get(   users.hasAccess, users.hasAny(users.requiresAdminRole, tags.requiresMember), tags.read)
 		.post(  users.hasAccess, users.hasAny(users.requiresAdminRole, tags.requiresEditor), tags.update)
@@ -26,3 +104,22 @@ module.exports = function(app) {
 	// Finish by binding the tag middleware
 	app.param('tagId', tags.tagById);
 };
+
+// Swagger Definitions
+
+/**
+ * @swagger
+ * definitions:
+ *   TagDto:
+ *     type: object
+ *     required: [name]
+ *     properties:
+ *       name:
+ *         type: string
+ *         example: Sample Name
+ *       description:
+ *         type: string
+ *         example: Sample Description
+ *       owner:
+ *         type: string
+ */

--- a/src/server/app/teams/routes/teams.server.routes.js
+++ b/src/server/app/teams/routes/teams.server.routes.js
@@ -11,12 +11,90 @@ module.exports = function(app) {
 	 * Team Routes
 	 */
 
+	/**
+	 * @swagger
+	 * /team:
+	 *   put:
+	 *     tags: [team]
+	 *     description: Creates a team.
+	 *     parameters:
+	 *     - in: body
+	 *       name: body
+	 *       required: true
+	 *       schema:
+	 *         $ref: '#/definitions/TeamDto'
+	 */
 	app.route('/team')
 		.put(users.hasEditorAccess, teams.create);
 
+	/**
+	 * @swagger
+	 * /teams:
+	 *   post:
+	 *     tags: [team]
+	 *     description: Search for teams with a specific word in the title or description.
+	 *     parameters:
+	 *     - in: body
+	 *       name: body
+	 *       required: true
+	 *       schema:
+	 *         type: object
+	 *         required: [s]
+	 *         properties:
+	 *           q:
+	 *             type: object
+	 *           s:
+	 *             type: string
+	 *     - in: query
+	 *       name: page
+	 *       type: integer
+	 *     - in: query
+	 *       name: size
+	 *       type: integer
+	 *     - in: query
+	 *       name: sort
+	 *       type: string
+	 *     - in: query
+	 *       name: dir
+	 *       type: string
+	 *       enum: [ASC, DESC]
+	 */
 	app.route('/teams')
 		.post(users.hasAccess, teams.search);
 
+	/**
+	 * @swagger
+	 * /team/{teamId}:
+	 *   get:
+	 *     tags: [team]
+	 *     description: Returns the team with given team id.
+	 *     parameters:
+	 *     - in: path
+	 *       name: teamId
+	 *       type: string
+	 *       required: true
+	 *   post:
+	 *     tags: [team]
+	 *     description: Updates the team's information with the given team id.
+	 *     parameters:
+	 *     - in: path
+	 *       name: teamId
+	 *       type: string
+	 *       required: true
+	 *     - name: body
+	 *       in: body
+	 *       required: true
+	 *       schema:
+	 *         $ref: '#/definitions/TeamDto'
+	 *   delete:
+	 *     tags: [team]
+	 *     description: Deletes the team with the given team id.
+	 *     parameters:
+	 *     - in: path
+	 *       name: teamId
+	 *       type: string
+	 *       required: true
+	 */
 	app.route('/team/:teamId')
 		.get(   users.hasAccess, users.hasAny(users.requiresAdminRole, teams.requiresMember), teams.read)
 		.post(  users.hasAccess, users.hasAny(users.requiresAdminRole, teams.requiresAdmin), teams.update)
@@ -25,13 +103,82 @@ module.exports = function(app) {
 	/**
 	 * Team editors Routes (requires team admin role)
 	 */
+
+	/**
+	 * @swagger
+	 * /team/{teamId}/members:
+	 *   post:
+	 *     tags: [team]
+	 *     description: Gets all members of a team.
+	 *     parameters:
+	 *     - in: path
+	 *       name: teamId
+	 *       required: true
+	 *       type: string
+	 */
 	app.route('/team/:teamId/members')
 		.post(users.hasAccess, users.hasAny(users.requiresAdminRole, teams.requiresMember), teams.searchMembers);
 
+	/**
+	 * @swagger
+	 * /team/{teamId}/member/{memberId}:
+	 *   post:
+	 *     tags: [team]
+	 *     description: Adds the user to the team.
+	 *     parameters:
+	 *     - in: path
+	 *       name: teamId
+	 *       required: true
+	 *       type: string
+	 *     - in: path
+	 *       name: memberId
+	 *       required: true
+	 *       type: string
+	 *     - in: body
+	 *       name: body
+	 *       required: true
+	 *       type: object
+	 *       schema:
+	 *         $ref: '#/definitions/BodyRole'
+	 *   delete:
+	 *     tags: [team]
+	 *     description: Removes the user from the team.
+	 *     parameters:
+	 *     - in: path
+	 *       name: teamId
+	 *       required: true
+	 *       type: string
+	 *     - in: path
+	 *       name: memberId
+	 *       required: true
+	 *       type: string
+	 */
 	app.route('/team/:teamId/member/:memberId')
 		.post(  users.hasAccess, users.hasAny(users.requiresAdminRole, teams.requiresAdmin), teams.addMember)
 		.delete(users.hasAccess, users.hasAny(users.requiresAdminRole, teams.requiresAdmin), teams.removeMember);
 
+	/**
+	 * @swagger
+	 * /team/{teamId}/member/{memberId}/role:
+	 *   post:
+	 *     tags: [team]
+	 *     description: Changes the role of a member on a team.
+	 *     parameters:
+	 *     - in: path
+	 *       name: teamId
+	 *       required: true
+	 *       type: string
+	 *     - in: path
+	 *       name: memberId
+	 *       required: true
+	 *       type: string
+	 *     - in: body
+	 *       name: body
+	 *       required: true
+	 *       type: object
+	 *       schema:
+	 *         $ref: '#/definitions/BodyRole'
+	 */
 	app.route('/team/:teamId/member/:memberId/role')
 		.post(  users.hasAccess, users.hasAny(users.requiresAdminRole, teams.requiresAdmin), teams.updateMemberRole);
 
@@ -40,3 +187,32 @@ module.exports = function(app) {
 	app.param('teamId', teams.teamById);
 	app.param('memberId', teams.teamUserById);
 };
+
+// Swagger Definitions
+
+/**
+ * @swagger
+ * definitions:
+ *   TeamDto:
+ *     type: object
+ *     required: [name]
+ *     properties:
+ *       name:
+ *         type: string
+ *         example: Sample Name
+ *       description:
+ *         type: string
+ *         example: Sample Description
+ *       requiresExternalTeams:
+ *         type: array
+ *         example: []
+ *         items:
+ *           type: string
+ *   BodyRole:
+ *     type: object
+ *     required: [role]
+ *     properties:
+ *       role:
+ *         type: string
+ *         enum: [member, editor, admin]
+ */

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -156,7 +156,7 @@ let initGlobalConfigFiles = (config, assets) => {
  */
 let initGlobalConfig = () => {
 
-	// Validate NDOE_ENV existance
+	// Validate NODE_ENV existence
 	validateEnvironmentVariable();
 
 	// Get the default config

--- a/src/server/lib/express.js
+++ b/src/server/lib/express.js
@@ -235,22 +235,15 @@ function initModulesServerSockets(app) {
 }
 
 function initSwagger(app) {
-	let swaggerOptions = {
-		swaggerDefinition: {
-			info: {
-				title: 'MEAN2 REST API',
-				version: '1.0.0',
-				description: 'This is a REST API for the MEAN2 starter app.',
-				contact: {
-					email: 'help@asymmetrik.com'
-				}
-			}
-		},
-		apis: config.files.server.routes.map(function(r) {return './' + r;})
-	};
+	if (config.showApi === true) {
+		let swaggerOptions = {
+			swaggerDefinition: config.apiConfig,
+			apis: config.files.server.routes.map(function(r) {return './' + r;})
+		};
 
-	let swaggerSpec = swaggerJsDoc(swaggerOptions);
-	app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+		let swaggerSpec = swaggerJsDoc(swaggerOptions);
+		app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+	}
 }
 
 /**

--- a/src/server/lib/express.js
+++ b/src/server/lib/express.js
@@ -19,6 +19,8 @@ let path = require('path'),
 	methodOverride = require('method-override'),
 	morgan = require('morgan'),
 	passport = require('passport'),
+	swaggerJsDoc = require('swagger-jsdoc'),
+	swaggerUi = require('swagger-ui-express'),
 
 	MongoStore = require('connect-mongo')(session);
 
@@ -232,6 +234,25 @@ function initModulesServerSockets(app) {
 	});
 }
 
+function initSwagger(app) {
+	let swaggerOptions = {
+		swaggerDefinition: {
+			info: {
+				title: 'MEAN2 REST API',
+				version: '1.0.0',
+				description: 'This is a REST API for the MEAN2 starter app.',
+				contact: {
+					email: 'help@asymmetrik.com'
+				}
+			}
+		},
+		apis: config.files.server.routes.map(function(r) {return './' + r;})
+	};
+
+	let swaggerSpec = swaggerJsDoc(swaggerOptions);
+	app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+}
+
 /**
  * Configure error handling
  */
@@ -329,6 +350,9 @@ module.exports.init = function (db) {
 
 	// Initialize modules sockets
 	initModulesServerSockets(app);
+
+	// Initialize Swagger
+	initSwagger(app);
 
 	// Initialize error routes
 	initErrorRoutes(app);


### PR DESCRIPTION
This is some initial work for using swagger-ui and js-doc to automatically create a REST API for mean2-starter that can be reached from a web page (/api-docs).

[swagger-ui-express](https://www.npmjs.com/package/swagger-ui-express) and [swagger-js-doc](https://www.npmjs.com/package/swagger-jsdoc) are used to generate the page. Login information is shared between the main app and swagger, but you can also sign in/out using the auth calls.