### PR TITLE
Fixing the priority of the custom button style selectors

### DIFF
--- a/config/build/webpack.conf.js
+++ b/config/build/webpack.conf.js
@@ -115,7 +115,7 @@ module.exports = (mode) => {
 			{ test: /\.css$/, loaders: [ 'style-loader?insertAt=top', 'css-loader' ] },
 
 			// SCSS loader
-			{ test: /\.scss$/, loaders: [ 'style-loader', 'css-loader', 'sass-loader' ] },
+			{ test: /\.scss$/, loaders: [ 'style-loader?insertAt=top', 'css-loader', 'sass-loader' ] },
 
 			// Image file loader
 			{ test: /\.png$/, loader: 'url-loader?limit=10000&mimetype=image/png' },

--- a/src/client/app/shared/general.scss
+++ b/src/client/app/shared/general.scss
@@ -156,71 +156,74 @@ dl {
 //	Buttons
 //=====================================
 
-.btn-link {
-	background: none;
-	border: 0;
+.btn {
 
-	&.subtle {
-		color: $color-label-gray;
+	&.btn-link {
+		background: none;
+		border: 0;
 
-		&:hover {
-			color: $color-border-dark;
+		&.subtle {
+			color: $color-label-gray;
+
+			&:hover {
+				color: $color-border-dark;
+			}
+		}
+
+		&.danger {
+			&:hover {
+				color: $color-danger-med;
+			}
 		}
 	}
 
-	&.danger {
-		&:hover {
-			color: $color-danger-med;
+	&.btn-selected {
+		background-color: $color-bg-btn;
+		background-image: none;
+		border-color: $color-border-btn;
+		color: $color-text-black;
+
+		&:focus {
+			border-color: $color-border-med;
 		}
-	}
-}
 
-.btn-selected {
-	background-color: $color-bg-btn;
-	background-image: none;
-	border-color: $color-border-btn;
-	color: $color-text-black;
+		&:hover {
+			border-color: $color-border-med;
+		}
 
-	&:focus {
-		border-color: $color-border-med;
-	}
-
-	&:hover {
-		border-color: $color-border-med;
-	}
-
-	&:active {
-		border-color: $color-border-med;
-	}
-
-	&.active {
 		&:active {
 			border-color: $color-border-med;
 		}
-	}
-}
 
-.btn-unselected {
-	background-color: $color-white;
-	background-image: none;
-	border-color: $color-border-dark;
-	color: $color-text-black;
-
-	&:focus {
-		border-color: $color-border-med;
+		&.active {
+			&:active {
+				border-color: $color-border-med;
+			}
+		}
 	}
 
-	&:hover {
-		border-color: $color-border-med;
-	}
+	&.btn-unselected {
+		background-color: $color-white;
+		background-image: none;
+		border-color: $color-border-dark;
+		color: $color-text-black;
 
-	&:active {
-		border-color: $color-border-med;
-	}
+		&:focus {
+			border-color: $color-border-med;
+		}
 
-	&.active {
+		&:hover {
+			border-color: $color-border-med;
+		}
+
 		&:active {
 			border-color: $color-border-med;
+		}
+
+		&.active {
+			&:active {
+				border-color: $color-border-med;
+			}
 		}
 	}
 }


### PR DESCRIPTION
The button type specific selectors were at the same priority as the base .btn selector, as a result, the styles were losing due to the order of inclusion of style specifications. This should make the button style selectors more specific so they win.

Also updated the scss style importer to also use importAt=top for consistency. Because we build application css manually, this will have the effect of ordering library css/scss first, which should allow application-specific css/scss to win in selector ties.

See: https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity