### PR TITLE
Remove remaining references to Sentio and D3.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -133,15 +133,19 @@ gulp.task('build-client-code', ['lint-client-code'], (done) => {
 
 	webpack(webpackConfig('build'), (err, stats) => {
 
-		// Fail if there were errors
-		if(err) throw new plugins.util.PluginError('webpack', err);
+		// Fail if there were errors initiating webpack
+		if(err) return done(new plugins.util.PluginError('webpack', err));
 
 		// log the stats from webpack
 		plugins.util.log('[webpack]', stats.toString({
 			colors: true, chunks: false
 		}));
 
-		done();
+		let buildErrors;
+		if (stats.hasErrors()) {
+			buildErrors = new plugins.util.PluginError('webpack', 'Errors during webpack build. See webpack output for details.');
+		}
+		done(buildErrors);
 	});
 });
 

--- a/src/client/vendor.ts
+++ b/src/client/vendor.ts
@@ -42,12 +42,6 @@ import 'angular2-modal';
 
 
 // Other Dependencies
-import 'd3';
 import 'lodash';
 import 'moment';
 import 'rxjs';
-
-import '@asymmetrik/sentio/dist/sentio.css';
-import '@asymmetrik/sentio';
-import '@asymmetrik/angular2-sentio';
-


### PR DESCRIPTION
Gulp build was reporting missing files for D3 and Sentio, but was not exiting with non-zero.

Updated gulp build to exit with non-zero in such a case, and added the missing files to package.json.

Edit: Since these files were actually removed from package.json on purpose, updated this PR to instead remove the remaining references to Sentio and D3 that were causing the build errors.