### PR TITLE
Add option to hide title field from resource metadata options

### DIFF
--- a/src/client/app/resources/manage-resource-metadata.component.html
+++ b/src/client/app/resources/manage-resource-metadata.component.html
@@ -5,7 +5,7 @@
 	</div>
 
 	<!-- Title -->
-	<div class="form-group row col-md-12">
+	<div class="form-group row col-md-12" *ngIf="!hideTitle">
 		<label for="title">Title<span class="text-danger"><strong> *</strong></span></label>
 		<input type="text" class="form-control input-sm" id="title" name="title" [(ngModel)]="resource.title" required />
 	</div>

--- a/src/client/app/resources/manage-resource-metadata.component.ts
+++ b/src/client/app/resources/manage-resource-metadata.component.ts
@@ -22,6 +22,8 @@ export class ManageResourceMetadataComponent {
 
 	@Input() mode: string;
 
+	@Input() hideTitle: boolean = false;
+
 	@Output() alertError = new EventEmitter();
 
 	private ownerOptions: Owner[] = [];


### PR DESCRIPTION
Add the option to hide the title from the resource metadata options.

This was necessary when we wanted to create multiple resources which could share owner and tags, but not necessarily the same title.
