### PR TITLE
Add support for IE 9+

### DIFF
--- a/config/build/tslint.conf.js
+++ b/config/build/tslint.conf.js
@@ -25,7 +25,7 @@ module.exports = {
 			"no-bitwise": true,
 			"no-conditional-assignment": true,
 			"no-consecutive-blank-lines": false,
-			"no-console": [ false ],
+			"no-console": [ true, 'debug' ],
 			"no-construct": true,
 			"no-debugger": true,
 			"no-duplicate-key": true,

--- a/config/build/webpack.conf.js
+++ b/config/build/webpack.conf.js
@@ -4,7 +4,6 @@ let
 	path = require('path'),
 	webpack = require('webpack'),
 
-	config = require(path.resolve('./src/server/config.js')),
 	assets = require(path.resolve('./config/assets.js'));
 
 module.exports = (mode) => {
@@ -70,7 +69,7 @@ module.exports = (mode) => {
 	// If develop mode, set up for dev middleware
 	else if(develop) {
 		wpConfig.output.path = path.resolve('./public');
-		wpConfig.output.publicPath = 'http://localhost:' + config.port + '/dev';
+		wpConfig.output.publicPath = '/dev/';
 		wpConfig.output.filename = '[name].js';
 		wpConfig.output.chunkFilename = '[name].js';
 	}

--- a/package.json
+++ b/package.json
@@ -70,6 +70,8 @@
 		"@angular/router": "3.1.1",
 
 		"core-js": "2.4",
+		"classlist.js": "1.1",
+		"console-polyfill": "0.2.3",
 		"reflect-metadata": "0.1",
 		"rxjs": "5.0.0-rc.4",
 		"zone.js": "0.7",

--- a/src/client/app/admin/authentication/user-state.service.ts
+++ b/src/client/app/admin/authentication/user-state.service.ts
@@ -23,7 +23,6 @@ export class UserStateService {
 		let redirect = this.authRedirectUrl ? this.authRedirectUrl : '/';
 		redirect = redirect.split(';')[0];
 		// Redirect the user
-		console.log(`Redirecting user to ${redirect}`);
 		this.router.navigate([redirect]);
 	}
 

--- a/src/client/app/admin/authentication/user-state.service.ts
+++ b/src/client/app/admin/authentication/user-state.service.ts
@@ -23,7 +23,7 @@ export class UserStateService {
 		let redirect = this.authRedirectUrl ? this.authRedirectUrl : '/';
 		redirect = redirect.split(';')[0];
 		// Redirect the user
-		console.debug(`Redirecting user to ${redirect}`);
+		console.log(`Redirecting user to ${redirect}`);
 		this.router.navigate([redirect]);
 	}
 

--- a/src/client/app/admin/end-user-agreement/user-eua.component.ts
+++ b/src/client/app/admin/end-user-agreement/user-eua.component.ts
@@ -29,12 +29,10 @@ export class UserEuaComponent {
 	private accept() {
 		this.authService.acceptEua()
 			.subscribe(() => {
-				console.log('Accepted EUA for user.');
 				this.userStateService.goToRedirectRoute();
 			},
 			(error: any) => {
 				this.alertService.addAlert(error.message);
-				console.error('Error persisting EUA accept');
 			});
 	};
 }

--- a/src/client/app/admin/password/forgot-password.component.ts
+++ b/src/client/app/admin/password/forgot-password.component.ts
@@ -52,7 +52,7 @@ export class ForgotPasswordComponent {
 			this.error = 'Missing username.';
 		}
 		else {
-			console.debug(`Requesting password reset for user ${this.username}`);
+			console.log(`Requesting password reset for user ${this.username}`);
 			this.pending = 'Processing request...';
 			this.authService.forgotPassword(this.username)
 				.subscribe(

--- a/src/client/app/admin/password/forgot-password.component.ts
+++ b/src/client/app/admin/password/forgot-password.component.ts
@@ -52,7 +52,6 @@ export class ForgotPasswordComponent {
 			this.error = 'Missing username.';
 		}
 		else {
-			console.log(`Requesting password reset for user ${this.username}`);
 			this.pending = 'Processing request...';
 			this.authService.forgotPassword(this.username)
 				.subscribe(

--- a/src/client/app/audit/audit-object.component.ts
+++ b/src/client/app/audit/audit-object.component.ts
@@ -54,7 +54,6 @@ export class AuditObjectComponent {
 
 	ngOnInit() {
 		if (!AuditObjectTypes.objects.hasOwnProperty(this.auditType)) {
-			console.warn(`WARNING: Improperly configured audit type: ${this.auditType}.  Using default.`);
 			this.auditType = 'default';
 		}
 

--- a/src/client/app/config/test/test-stub-service.service.ts
+++ b/src/client/app/config/test/test-stub-service.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 @Injectable()
 export class BaseService {
 	constructor() {
-		console.log('BaseService constructor');
+
 	}
 
 	public whoAmI(): string {
@@ -14,7 +14,7 @@ export class BaseService {
 @Injectable()
 export class BaseService2 {
 	constructor() {
-		console.log('BaseService2 constructor');
+
 	}
 
 	public whoAmI(): string {

--- a/src/client/app/core/auth-guard.service.ts
+++ b/src/client/app/core/auth-guard.service.ts
@@ -22,9 +22,7 @@ export class AuthGuard implements CanActivate {
 		return Observable.create( (observer: Observer<boolean>) => {
 			this.authService.initializing$
 				.subscribe( (isInitializing: boolean) => {
-					console.log(`AuthService isInitializing: ${isInitializing}`);
 					if (!isInitializing) {
-						console.log('AuthService done initializing, AuthGuard is evaluating access');
 						let url: string = state.url;
 						observer.next(this.checkAccess(url, route));
 						observer.complete();
@@ -54,7 +52,6 @@ export class AuthGuard implements CanActivate {
 
 		// If the route requires authentication and the user is not authenticated, then go to the signin route
 		if (url !== '/signin' && requiresAuthentication && !this.userStateService.isAuthenticated()) {
-			console.log('UserState: User is not authenticated, go to signin');
 			// Store the attempted URL so we can redirect after successful login
 			this.userStateService.authRedirectUrl = url;
 			this.router.navigate(['/signin']);
@@ -68,7 +65,6 @@ export class AuthGuard implements CanActivate {
 		if (this.userStateService.isAuthenticated() && !this.userStateService.user.isAdmin() && !this.userStateService.user.isEuaCurrent() ) {
 			if (url !== '/user-eua') {
 				this.userStateService.authRedirectUrl = url;
-				console.log('UserState: User is authenticated, but needs to accept EUA, go to user-eua');
 				this.router.navigate(['/user-eua']);
 				return false;
 			}
@@ -100,7 +96,6 @@ export class AuthGuard implements CanActivate {
 					// If the user is missing the user role, they are pending
 					if (url !== '/inactive-user') {
 						this.userStateService.authRedirectUrl = url;
-						console.log('UserState: User is authenticated, but account is not active, go to inactive-user');
 						this.router.navigate(['/inactive-user']);
 						return false;
 					}
@@ -109,7 +104,6 @@ export class AuthGuard implements CanActivate {
 					// The user doesn't have the needed roles to view the page
 					if (url !== '/unauthorized') {
 						this.userStateService.authRedirectUrl = url;
-						console.log('UserState: User is authenticated, but doesn\'t have the roles needed to view the page, go to user.unauthorized');
 						this.router.navigate(['/unauthorized']);
 						return false;
 					}

--- a/src/client/app/core/auth-guard.service.ts
+++ b/src/client/app/core/auth-guard.service.ts
@@ -22,9 +22,9 @@ export class AuthGuard implements CanActivate {
 		return Observable.create( (observer: Observer<boolean>) => {
 			this.authService.initializing$
 				.subscribe( (isInitializing: boolean) => {
-					console.debug(`AuthService isInitializing: ${isInitializing}`);
+					console.log(`AuthService isInitializing: ${isInitializing}`);
 					if (!isInitializing) {
-						console.debug('AuthService done initializing, AuthGuard is evaluating access');
+						console.log('AuthService done initializing, AuthGuard is evaluating access');
 						let url: string = state.url;
 						observer.next(this.checkAccess(url, route));
 						observer.complete();
@@ -54,7 +54,7 @@ export class AuthGuard implements CanActivate {
 
 		// If the route requires authentication and the user is not authenticated, then go to the signin route
 		if (url !== '/signin' && requiresAuthentication && !this.userStateService.isAuthenticated()) {
-			console.debug('UserState: User is not authenticated, go to signin');
+			console.log('UserState: User is not authenticated, go to signin');
 			// Store the attempted URL so we can redirect after successful login
 			this.userStateService.authRedirectUrl = url;
 			this.router.navigate(['/signin']);
@@ -68,7 +68,7 @@ export class AuthGuard implements CanActivate {
 		if (this.userStateService.isAuthenticated() && !this.userStateService.user.isAdmin() && !this.userStateService.user.isEuaCurrent() ) {
 			if (url !== '/user-eua') {
 				this.userStateService.authRedirectUrl = url;
-				console.debug('UserState: User is authenticated, but needs to accept EUA, go to user-eua');
+				console.log('UserState: User is authenticated, but needs to accept EUA, go to user-eua');
 				this.router.navigate(['/user-eua']);
 				return false;
 			}
@@ -100,7 +100,7 @@ export class AuthGuard implements CanActivate {
 					// If the user is missing the user role, they are pending
 					if (url !== '/inactive-user') {
 						this.userStateService.authRedirectUrl = url;
-						console.debug('UserState: User is authenticated, but account is not active, go to inactive-user');
+						console.log('UserState: User is authenticated, but account is not active, go to inactive-user');
 						this.router.navigate(['/inactive-user']);
 						return false;
 					}
@@ -109,7 +109,7 @@ export class AuthGuard implements CanActivate {
 					// The user doesn't have the needed roles to view the page
 					if (url !== '/unauthorized') {
 						this.userStateService.authRedirectUrl = url;
-						console.debug('UserState: User is authenticated, but doesn\'t have the roles needed to view the page, go to user.unauthorized');
+						console.log('UserState: User is authenticated, but doesn\'t have the roles needed to view the page, go to user.unauthorized');
 						this.router.navigate(['/unauthorized']);
 						return false;
 					}

--- a/src/client/app/messages/admin/list-messages.component.ts
+++ b/src/client/app/messages/admin/list-messages.component.ts
@@ -119,7 +119,6 @@ export class ListMessagesComponent {
 				this.results.resolved = true;
 			}, (error) => {
 				this.alertService.addAlert(error.message);
-				console.error(error);
 				this.results.resolved = true;
 			});
 	}

--- a/src/client/app/messages/message.service.ts
+++ b/src/client/app/messages/message.service.ts
@@ -70,7 +70,6 @@ export class MessageService {
 	public subscribe() {
 		if (this.subscribed === 0) {
 			this.socketService.emit('message:subscribe');
-			console.log('Socket.io: Subscribing to messages');
 		}
 		this.subscribed++;
 	}
@@ -80,7 +79,6 @@ export class MessageService {
 
 		if (this.subscribed === 0) {
 			this.socketService.emit('message:unsubscribe');
-			console.log('Socket.io: Unsubscribed from messages');
 		}
 		else if (this.subscribed < 0) {
 			this.subscribed = 0;
@@ -103,14 +101,11 @@ export class MessageService {
 		this.socketService.on('message:data', this.payloadRouterFn);
 
 		this.socketService.on('disconnect', () => {
-			if (this.subscribed > 0) {
-				console.info('Socket.io: Disconnected from message...');
-			}
+
 		});
 
 		this.socketService.on('reconnect', () => {
 			if (this.subscribed > 0) {
-				console.info('Socket.io: Reconnecting to message...');
 				this.socketService.emit('feedstatus:subscribe');
 			}
 		});

--- a/src/client/app/shared/asy-http.service.ts
+++ b/src/client/app/shared/asy-http.service.ts
@@ -37,7 +37,7 @@ export class AsyHttp {
 		private route: ActivatedRoute) {}
 
 	static defaultErrFn(err: any) {
-		console.log(`Error retrieving url`, err);
+
 	}
 
 	get(opts: HttpOptions) {
@@ -153,7 +153,6 @@ export class AsyHttp {
 
 				if (errData.type === 'invalid-certificate') {
 					// Redirect to invalid credentials page
-					console.log(`UserState: Server doesn't recognize the submitted cert, go to the invalid cert page`);
 					this.router.navigate(['/invalid-certificate']);
 				}
 				else {
@@ -163,20 +162,16 @@ export class AsyHttp {
 				break;
 			case 403:
 				if (errData.type === 'eua') {
-					console.log(`UserState: Server thinks the user needs to accept eua, go to eua`);
 					this.router.navigate(['/user-eua']);
 				}
 				else if (errData.type === 'inactive') {
-					console.log(`UserState: Server thinks the user is inactive, go to inactive`);
 					this.router.navigate(['/inactive-user']);
 				}
 				else if (errData.type === 'noaccess') {
-					console.log(`UserState: Server thinks the user does not have the required access, go to user.noaccess`);
 					this.router.navigate(['/no-access']);
 				}
 				else {
 					// Add unauthorized behavior
-					console.log(`UserState: Server thinks the user accessed something they shouldn\'t, go to user.unauthorized`);
 					this.router.navigate(['/unauthorized']);
 				}
 				break;

--- a/src/client/app/shared/asy-http.service.ts
+++ b/src/client/app/shared/asy-http.service.ts
@@ -153,7 +153,7 @@ export class AsyHttp {
 
 				if (errData.type === 'invalid-certificate') {
 					// Redirect to invalid credentials page
-					console.debug(`UserState: Server doesn't recognize the submitted cert, go to the invalid cert page`);
+					console.log(`UserState: Server doesn't recognize the submitted cert, go to the invalid cert page`);
 					this.router.navigate(['/invalid-certificate']);
 				}
 				else {
@@ -163,20 +163,20 @@ export class AsyHttp {
 				break;
 			case 403:
 				if (errData.type === 'eua') {
-					console.debug(`UserState: Server thinks the user needs to accept eua, go to eua`);
+					console.log(`UserState: Server thinks the user needs to accept eua, go to eua`);
 					this.router.navigate(['/user-eua']);
 				}
 				else if (errData.type === 'inactive') {
-					console.debug(`UserState: Server thinks the user is inactive, go to inactive`);
+					console.log(`UserState: Server thinks the user is inactive, go to inactive`);
 					this.router.navigate(['/inactive-user']);
 				}
 				else if (errData.type === 'noaccess') {
-					console.debug(`UserState: Server thinks the user does not have the required access, go to user.noaccess`);
+					console.log(`UserState: Server thinks the user does not have the required access, go to user.noaccess`);
 					this.router.navigate(['/no-access']);
 				}
 				else {
 					// Add unauthorized behavior
-					console.debug(`UserState: Server thinks the user accessed something they shouldn\'t, go to user.unauthorized`);
+					console.log(`UserState: Server thinks the user accessed something they shouldn\'t, go to user.unauthorized`);
 					this.router.navigate(['/unauthorized']);
 				}
 				break;

--- a/src/client/app/teams/tags/list-tags.component.ts
+++ b/src/client/app/teams/tags/list-tags.component.ts
@@ -81,7 +81,6 @@ export class ListTagsComponent {
 					}
 				},
 				(err: any) => {
-					console.error(err);
 					this.loading = false;
 				},
 				() => {

--- a/src/client/vendor.ts
+++ b/src/client/vendor.ts
@@ -18,6 +18,10 @@
  */
 
 // Polyfills
+import 'core-js/es6';
+import 'core-js/es7/reflect';
+import 'classlist.js';
+import 'console-polyfill';
 import 'reflect-metadata';
 import 'zone.js';
 


### PR DESCRIPTION
Adds basic support for IE9+.

Console.debug is not available in these browsers, so I replaced those lines with console.log. According to MDN, console.debug is simply an alias for console.log, but it looks like chrome does print them differently. We may want to consider changing those logs to a dedicated logger whose level we can specify per environment.