### PR TITLE
Add option to hide description field from resource metadata options

### DIFF
--- a/src/client/app/resources/manage-resource-metadata.component.html
+++ b/src/client/app/resources/manage-resource-metadata.component.html
@@ -31,7 +31,7 @@
 	</div>
 
 	<!-- Description -->
-	<div class="form-group row col-md-12">
+	<div class="form-group row col-md-12" *ngIf="!hideDescription">
 		<label for="description">Description</label>
 		<textarea rows="3" class="form-control input-sm" id="description" name="description" [(ngModel)]="resource.description"></textarea>
 	</div>

--- a/src/client/app/resources/manage-resource-metadata.component.ts
+++ b/src/client/app/resources/manage-resource-metadata.component.ts
@@ -24,6 +24,8 @@ export class ManageResourceMetadataComponent {
 
 	@Input() hideTitle: boolean = false;
 
+	@Input() hideDescription: boolean = false;
+
 	@Output() alertError = new EventEmitter();
 
 	private ownerOptions: Owner[] = [];


### PR DESCRIPTION
Add the option to hide the description from the resource metadata options.

This is useful when we want to import several resources, each with their own preexisting descriptions.