### PR TITLE
Generic export

### DIFF
--- a/src/client/app/admin/user-management/admin-list-users.component.ts
+++ b/src/client/app/admin/user-management/admin-list-users.component.ts
@@ -295,7 +295,7 @@ export class AdminListUsersComponent {
 				{key: 'roles.admin', title: 'Admin Role'});
 		}
 
-		this.exportConfigService.postCSVParams('user', {
+		this.exportConfigService.postExportConfig('user', {
 			q: this.getQuery(),
 			s: this.search,
 			cols: viewColumns,

--- a/src/client/app/shared/export-config.service.ts
+++ b/src/client/app/shared/export-config.service.ts
@@ -9,8 +9,8 @@ export class ExportConfigService {
 	constructor(private asyHttp: AsyHttp) {
 	}
 
-	postCSVParams(type: string, config: any) {
-		return this.asyHttp.post(new HttpOptions('/admin/requestCSV',
+	postExportConfig(type: string, config: any) {
+		return this.asyHttp.post(new HttpOptions('/requestExport',
 			() => {},
 			{type: type, config: config}));
 	};

--- a/src/server/app/admin/controllers/users/users.export.server.controller.js
+++ b/src/server/app/admin/controllers/users/users.export.server.controller.js
@@ -107,7 +107,7 @@ exports.adminGetCSV = (req, res) => {
 							user.teams = teamNames.join(', ');
 						});
 					}
-					exportConfigController.exportData(req, res, fileName, columns, userData);
+					exportConfigController.exportCSV(req, res, fileName, columns, userData);
 				});
 		}, (error) => {
 			utilService.handleErrorResponse(res, error);

--- a/src/server/app/util/controllers/export-config.server.controller.js
+++ b/src/server/app/util/controllers/export-config.server.controller.js
@@ -3,6 +3,7 @@
 let path = require('path'),
 	stream = require('stream'),
 	q = require('q'),
+	os = require('os'),
 
 	deps = require(path.resolve('./src/server/dependencies.js')),
 	dbs = deps.dbs,

--- a/src/server/app/util/controllers/export-config.server.controller.js
+++ b/src/server/app/util/controllers/export-config.server.controller.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var
-	path = require('path'),
+let path = require('path'),
 	stream = require('stream'),
 	q = require('q'),
 
@@ -21,7 +20,7 @@ var
  * expire after a number of minutes (see export-config.server.service).
  */
 
-exports.adminRequestCSV = function(req, res) {
+exports.requestExport = function(req, res) {
 	if (null != req.body.config.q) {
 		// Stringify the query JSON because '$' is reserved in Mongo.
 		req.body.config.q = JSON.stringify(req.body.config.q);
@@ -31,25 +30,26 @@ exports.adminRequestCSV = function(req, res) {
 	}
 
 	exportConfigService.generateConfig(req)
-		.then(function(generatedConfig) {
-			return auditService.audit(`${req.body.type} csv config created`, 'export', 'create',
-				User.auditCopy(req.user, utilService.getHeaderField(req.headers, 'x-real-ip')),
-				ExportConfig.auditCopy(generatedConfig), req.headers)
-				.then(function() {
-					return q(generatedConfig);
-				});
-		})
-		.then(function(result) {
-			res.status(200).json({ _id: result._id});
-		}, function(err) {
-			utilService.handleErrorResponse(res, err);
-		}).done();
+		.then(
+			(generatedConfig) => {
+				return auditService.audit(`${req.body.type} csv config created`, 'export', 'create',
+					User.auditCopy(req.user, utilService.getHeaderField(req.headers, 'x-real-ip')),
+					ExportConfig.auditCopy(generatedConfig), req.headers)
+					.then(() => {
+						return q(generatedConfig);
+					});
+			})
+		.then(
+			(result) => {
+				res.status(200).json({ _id: result._id});
+			},
+			(err) => {
+				utilService.handleErrorResponse(res, err);
+			})
+		.done();
 };
 
-/**
- * Generic function to create CSV from data with the requested filename and columns
- */
-exports.exportData = function(req, res, filename, columns, data) {
+exports.exportCSV = function(req, res, filename, columns, data) {
 
 	if (null !== data) {
 		// Set up streaming res
@@ -58,21 +58,21 @@ exports.exportData = function(req, res, filename, columns, data) {
 		res.set('Transfer-Encoding', 'chunked');
 
 		// Put into stream the data object
-		var s = new stream.Readable({objectMode:true});
-		s._read = function() {
-			data.forEach(function(row) {
+		let s = new stream.Readable({objectMode:true});
+		s._read = () => {
+			data.forEach((row) => {
 				s.push(row);
 			});
 			s.push(null);
 		};
 
-		var sc = s.pipe(csvStream(columns));
+		let sc = s.pipe(csvStream(columns));
 
 		// Pipe each row to the response
 		sc.pipe(res);
 
 		// If an error occurs, close the stream
-		s.on('error', function(err) {
+		s.on('error', (err) => {
 			logger.error(err, 'CSV export error occurred');
 
 			// End the download
@@ -80,7 +80,7 @@ exports.exportData = function(req, res, filename, columns, data) {
 		});
 
 		// If the client drops the connection, stop processing the stream
-		req.on('close', function() {
+		req.on('close', () => {
 			logger.info('CSV export aborted because client dropped the connection');
 			if (s != null) {
 				s.destroy();

--- a/src/server/app/util/routes/export-config.server.routes.js
+++ b/src/server/app/util/routes/export-config.server.routes.js
@@ -9,6 +9,6 @@ var
 
 module.exports = function(app) {
 	// Admin post CSV config parameters
-	app.route('/admin/requestCSV')
-		.post(users.hasAdminAccess, exportConfig.adminRequestCSV);
+	app.route('/requestExport')
+		.post(users.hasAccess, exportConfig.requestExport);
 };


### PR DESCRIPTION
Export need not be CSV only. Make export more configurable and implement plaintext export as an example.

To test this functionality, check out **example-export** and run the UI. That feature branch uses plaintext export to download "hello world."