### PR TITLE
Pull in vendor and config code into test environment

### DIFF
--- a/config/build/karma/karma-test-shim.js
+++ b/config/build/karma/karma-test-shim.js
@@ -11,6 +11,9 @@ require('zone.js/dist/jasmine-patch');
 require('zone.js/dist/async-test');
 require('zone.js/dist/fake-async-test');
 
+require('../../../src/client/vendor.ts');
+require('../../../src/client/configuration.ts');
+
 var appContext = require.context('../../../src/client', true, /\.spec\.ts/);
 
 appContext.keys().forEach(appContext);


### PR DESCRIPTION
Adding these two files enables reusing Modules or other code during testing that depends on specific code that runs as part of the vendor or config setup. For example, the UtilModule depends on the config code having ran to setup the url handler class. Without this, modules such as the UtilModule cannot be brought in to test components that depend on the UtilModule.

While stubs are possible to work around this, sometimes in integration testing we want to use the true dependency.