### PR TITLE
Configure codeclimate checks

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,25 @@
+---
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - javascript
+  eslint:
+    enabled: true
+    channel: eslint-3
+    config:
+      extensions:
+      - ".js"
+  fixme:
+    enabled: true
+ratings:
+  paths:
+  - "src/**/*.js"
+exclude_paths:
+- "src/**/*.spec.js"
+- config/
+- node_modules/
+- reports/
+
+

--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,7 @@ tab_width = 4
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.yml]
+indent_style = spaces
+indent_size = 2

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,6 @@
 {
 	"env": {
+		"es6": true,
 		"node": true,
 		"mocha": true
 	},

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -108,7 +108,7 @@ gulp.task('watch-client', () => {
 gulp.task('lint-server', () => {
 	return gulp.src(_.union(assets.server.allJS, assets.tests.server, assets.build))
 		// ESLint
-		.pipe(plugins.eslint('./config/build/eslint.conf.json'))
+		.pipe(plugins.eslint())
 		.pipe(plugins.eslint.format())
 		.pipe(plugins.eslint.failAfterError());
 });


### PR DESCRIPTION
- Adds the `.codeclimate.yml` file to reuse eslint rules from the config/build/eslint.conf.json
- Ensure editors respect yaml required spacing in `.yml` files.