### PR TITLE
Removing default role for new users

### DIFF
--- a/config/env/default.js
+++ b/config/env/default.js
@@ -60,8 +60,7 @@ module.exports = {
 //		autoLogin: true,
 //		autoCreateAccounts: true,
 //		requiredRoles: ['ROLE'],
-
-		defaultRoles: { user: true },
+//		defaultRoles: { user: true },
 
 		/*
 		 * Session settings are required regardless of auth strategy


### PR DESCRIPTION
We made this change to FH and I would assume that we don't want a new user to automatically get access to an application.  If others disagree then that is fine, but I think this makes the most sense.