### PR TITLE
Properly parsing dates and numbers and strings to maintain milliseconds

### DIFF
--- a/src/server/app/util/services/util.server.service.js
+++ b/src/server/app/util/services/util.server.service.js
@@ -116,10 +116,20 @@ module.exports.toLowerCase = function (v){
 };
 
 module.exports.dateParse = function (date) {
-	if (null == date)
+	if (_.isNil(date)) {
 		return null;
+	}
+	if(_.isDate(date)) {
+		return date.getTime();
+	}
+	if(_.isFinite(date)) {
+		return date;
+	}
+	if(_.isString(date)) {
+		return Date.parse(date);
+	}
 
-	return Date.parse(date);
+	return null;
 };
 
 /**

--- a/src/server/app/util/services/util.server.service.js
+++ b/src/server/app/util/services/util.server.service.js
@@ -115,21 +115,32 @@ module.exports.toLowerCase = function (v){
 	return (null != v)? v.toLowerCase(): undefined;
 };
 
+/**
+ * Parse an input as a date. Handles various types
+ * of inputs, such as Strings, Date objects, and Numbers.
+ *
+ * @param {date} The input representing a date / timestamp
+ * @returns The timestamp in milliseconds since the Unix epoch
+ */
 module.exports.dateParse = function (date) {
+
+	// Handle nil values by simply returning null
 	if (_.isNil(date)) {
 		return null;
 	}
-	if(_.isDate(date)) {
+
+	// Date object should return its time in milliseconds
+	if (_.isDate(date)) {
 		return date.getTime();
 	}
-	if(_.isFinite(date)) {
+
+	// A number that exists will be interpretted as millisecond
+	if (_.isFinite(date)) {
 		return date;
 	}
-	if(_.isString(date)) {
-		return Date.parse(date);
-	}
 
-	return null;
+	// Handle String, Object, etc.
+	return Date.parse(date);
 };
 
 /**

--- a/src/server/app/util/services/util.server.service.spec.js
+++ b/src/server/app/util/services/util.server.service.spec.js
@@ -4,6 +4,7 @@
  * Module dependencies.
  */
 var
+	should = require('should'),
 	path = require('path'),
 	deps = require(path.resolve('./src/server/dependencies.js')),
 	util = deps.utilService;
@@ -16,11 +17,11 @@ var
 /**
  * Unit tests
  */
-describe('Utils:', function() {
+describe('Utils:', () => {
 
-	describe('toMongoose:', function() {
+	describe('toMongoose:', () => {
 
-		it('should convert $date : {""} to new Date("")', function(done) {
+		it('should convert $date : {""} to new Date("")', () => {
 			var input = {hello: {there: 'you are', when: [{},{something:0},{$date:'2015-01-01T00:00:00.000Z'}]}, date: {$date:'2015-07-01T00:00:00.000Z'}};
 
 			var output = util.toMongoose(input);
@@ -33,10 +34,9 @@ describe('Utils:', function() {
 			output.hello.when[1].something.should.equal(0);
 			output.hello.when[2].getTime().should.equal(1420070400000);
 			output.date.getTime().should.equal(1435708800000);
-			done();
 		});
 
-		it('should convert $obj : {""} to mongoose.Types.ObjectId("")', function(done) {
+		it('should convert $obj : {""} to mongoose.Types.ObjectId("")', () => {
 			var input = {hello: {there: 'you are', when: [{},{something:0},{$obj:'000000000000000000000000'}]}, obj: {$obj:'000000000000000000000001'}};
 
 			var output = util.toMongoose(input);
@@ -51,7 +51,26 @@ describe('Utils:', function() {
 			output.hello.when[2].toHexString().should.equal('000000000000000000000000');
 			output.obj._bsontype.should.equal('ObjectID');
 			output.obj.toHexString().should.equal('000000000000000000000001');
-			done();
+		});
+
+	});
+
+	describe('Date Parse:', () => {
+
+		[
+			{ input: '2017-01-01T12:34:56.789Z',           expected: 1483274096789, name: 'should properly parse a date string' },
+			{ input: '2017-01-01T12:34Z',                  expected: 1483274040000, name: 'should properly parse a date without seconds' },
+			{ input: new Date('2017-01-01T12:34:56.789Z'), expected: 1483274096789, name: 'should properly parse a date object' },
+			{ input: 1483274096789,                        expected: 1483274096789, name: 'should properly parse a number' },
+			{ input: 1483274096,                           expected: 1483274096,    name: 'should properly parse a number that is not actually a date' },
+			{ input: null,                                 expected: null,          name: 'should handle null inputs' },
+			{ input: [1234],                               expected: null,          name: 'should return null for arrays' },
+			{ input: { id: 1 },                            expected: null,          name: 'should return null for objects' }
+		].forEach((test) => {
+			it(test.name, () => {
+				const actual = util.dateParse(test.input);
+				should(actual).equal(test.expected);
+			});
 		});
 
 	});

--- a/src/server/app/util/services/util.server.service.spec.js
+++ b/src/server/app/util/services/util.server.service.spec.js
@@ -57,16 +57,31 @@ describe('Utils:', () => {
 
 	describe('Date Parse:', () => {
 
-		[
-			{ input: '2017-01-01T12:34:56.789Z',           expected: 1483274096789, name: 'should properly parse a date string' },
-			{ input: '2017-01-01T12:34Z',                  expected: 1483274040000, name: 'should properly parse a date without seconds' },
-			{ input: new Date('2017-01-01T12:34:56.789Z'), expected: 1483274096789, name: 'should properly parse a date object' },
-			{ input: 1483274096789,                        expected: 1483274096789, name: 'should properly parse a number' },
-			{ input: 1483274096,                           expected: 1483274096,    name: 'should properly parse a number that is not actually a date' },
-			{ input: null,                                 expected: null,          name: 'should handle null inputs' },
-			{ input: [1234],                               expected: null,          name: 'should return null for arrays' },
-			{ input: { id: 1 },                            expected: null,          name: 'should return null for objects' }
-		].forEach((test) => {
+		[{
+			input: '2017-01-01T12:34:56.789Z',
+			expected: 1483274096789,
+			name: 'should properly parse a date string'
+		}, {
+			input: '2017-01-01T12:34Z',
+			expected: 1483274040000,
+			name: 'should properly parse a date without seconds'
+		}, {
+			input: new Date('2017-01-01T12:34:56.789Z'),
+			expected: 1483274096789,
+			name: 'should properly parse a date object'
+		}, {
+			input: 1483274096789,
+			expected: 1483274096789,
+			name: 'should properly parse a number'
+		}, {
+			input: 1483274096,
+			expected: 1483274096,
+			name: 'should properly parse a number that is not actually a date'
+		}, {
+			input: null,
+			expected: null,
+			name: 'should handle null inputs'
+		}].forEach((test) => {
 			it(test.name, () => {
 				const actual = util.dateParse(test.input);
 				should(actual).equal(test.expected);


### PR DESCRIPTION
This resolves the issue of the Mongoose schemas having a type with `get: util.dateParse` and losing the milliseconds when the objects are inspected, for example, with toJSON().

It looks like Date.parse() on a Date object does a `.toString` on the object instead of a `.toISOString`