### PR TITLE
Add default dataFn

### DIFF
--- a/src/client/app/shared/asy-http.service.ts
+++ b/src/client/app/shared/asy-http.service.ts
@@ -14,7 +14,7 @@ export class HttpOptions {
 
 	constructor (
 		public url: string,
-		public dataFn?: Function,
+		public dataFn: Function = () => {},
 		public data: any = {},
 		public completeFn: Function = (): any => null,
 		public errFn: Function = AsyHttp.defaultErrFn,


### PR DESCRIPTION
Because the dataFn in AsyHttp is called in the internal subscription for the various http operations, dataFn is not truly optional as marked.

Suggest we provide a default no-op function to enable calling the http operations without providing the dataFn parameter.