### PR TITLE
Giving copyright banner a color

### DIFF
--- a/src/client/app/core/core.scss
+++ b/src/client/app/core/core.scss
@@ -170,7 +170,7 @@ a {
 }
 
 .copyright {
-	background-color: inherit;
+	background-color: $color-border-light;
 	color: $color-default-dark;
 	font-size: 12px;
 	padding: 2px;


### PR DESCRIPTION
Currently there is no background and the copyright text can overlap with the app content.