### PR TITLE
Karma watches its own files

### DIFF
--- a/config/build/karma/karma.conf.js
+++ b/config/build/karma/karma.conf.js
@@ -1,8 +1,10 @@
 // Karma configuration
 // Generated on Wed Dec 14 2016 15:07:52 GMT-0500 (EST)
 
-const includeCodeCoverage = !!process.env.CODE_COVERAGE_ENABLED;
-const webpackEnvironment = includeCodeCoverage ? 'test-coverage' : 'test';
+const includeCodeCoverage = !!process.env.KARMA_CODE_COVERAGE_ENABLED;
+const ciMode = !!process.env.KARMA_CI_MODE;
+
+const webpackEnvironment = `test${ciMode ? ':ci' : ''}${includeCodeCoverage ? ':coverage' : ''}`;
 
 const webpackConfig = require('../webpack.conf')(webpackEnvironment);
 
@@ -26,7 +28,7 @@ module.exports = function(config) {
 
 		// list of files / patterns to load in the browser
 		files: [
-			{ pattern: karmaTestShim, watched: false }
+			{ pattern: karmaTestShim, watched: true }
 		],
 
 		// list of files to exclude
@@ -72,7 +74,7 @@ module.exports = function(config) {
 		logLevel: config.LOG_INFO,
 
 		// enable / disable watching file and executing tests whenever any file changes
-		autoWatch: false,
+		autoWatch: true,
 
 		// start these browsers
 		// available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
@@ -80,7 +82,7 @@ module.exports = function(config) {
 
 		// Continuous Integration mode
 		// if true, Karma captures browsers, runs the tests and exits
-		singleRun: true,
+		singleRun: ciMode,
 
 		// Concurrency level
 		// how many browser should be started simultaneous

--- a/config/build/webpack.conf.js
+++ b/config/build/webpack.conf.js
@@ -15,10 +15,10 @@ module.exports = (mode) => {
 	 *  'develop' - Running webpack dev middleware for development
 	 *  'test' - Running webpack for executing tests
 	 */
-	let build = (mode === 'build');
-	let develop = (mode === 'develop');
-	let test = (mode === 'test' || mode === 'test-coverage');
-	let coverage = (mode === 'test-coverage');
+	const build = (mode === 'build');
+	const develop = (mode === 'develop');
+	const test = mode.startsWith('test');
+	const coverage = mode.includes(':coverage');
 
 
 	// The main webpack config object to return

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -260,27 +260,14 @@ function runKarmaTest(additionalEnvironmentVariables, callback) {
 }
 
 gulp.task('test-client', ['env:test'], () => {
-
-	const clientFilesToWatch = _.union(
-			assets.tests.client,
-			assets.client.app.src.ts,
-			assets.client.app.src.sass,
-			assets.client.app.views,
-			assets.client.app.content,
-			assets.build
-	);
-
-	const minTimeBetweenTestsCalls = 5000;
-
-	const runKarmaTestWithDebounce = _.throttle(_.partial(runKarmaTest, {}, _.noop), minTimeBetweenTestsCalls);
-
-	gulp.watch(clientFilesToWatch, runKarmaTestWithDebounce);
-	runKarmaTestWithDebounce();
-
+	runKarmaTest({}, _.noop);
 });
 
 gulp.task('test-client-ci', ['env:test'], (done) => {
-	runKarmaTest({CODE_COVERAGE_ENABLED: '1'}, done);
+	runKarmaTest({
+		KARMA_CODE_COVERAGE_ENABLED: '1',
+		KARMA_CI_MODE: '1'
+	}, done);
 });
 
 gulp.task('coverage-init', () => {


### PR DESCRIPTION
The previous iteration of test-client had gulp watching whether files changed,
and triggered a new karma process for each set of changes. This caused webpack
to do an initial build each time instead of an incremental build. Right now,
these initial builds are fairly slow, leading to significant test running times
when attempting to do TDD or test first development.

These changes place the watch responsibility on the karma process itself
instead of the gulp task. karma-webpack is then able to reuse its build context
during subsequent runs of karma within the same process. While the inital run
for test-client will still take some amount of time due to the initial webpack
build, each additional run of tests while test-client is active will go fairly
fast.