### PR TITLE
Adding email server service for reusable emailing

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"morgan": "1.7",
 		"multer": "1.2",
 		"multipipe": "1.0",
-		"nodemailer": "3.0.2",
+		"nodemailer": "3.0",
 		"node-uuid": "1.4.7",
 		"platform": "1.3.3",
 		"passport": "0.3",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"morgan": "1.7",
 		"multer": "1.2",
 		"multipipe": "1.0",
-		"nodemailer": "2.6",
+		"nodemailer": "3.0.2",
 		"node-uuid": "1.4.7",
 		"platform": "1.3.3",
 		"passport": "0.3",

--- a/src/server/app/admin/controllers/users/users.password.server.controller.js
+++ b/src/server/app/admin/controllers/users/users.password.server.controller.js
@@ -198,10 +198,12 @@ exports.reset = (req, res, next) => {
 
 			emailService.sendMail(mailOptions)
 				.then((result) => {
+					logger.debug(`Sent email to: ${user.email}`);
+					res.json(`An email has been sent to ${user.email} letting them know their password was reset.`);
 					done(null);
-
 				}, (error) => {
 					logger.error({err: error, req: req}, 'Failure sending email.');
+					return res.status(400).json({ message: 'Failure sending email.' });
 				});
 		}
 	], (error) => {

--- a/src/server/app/admin/controllers/users/users.password.server.controller.js
+++ b/src/server/app/admin/controllers/users/users.password.server.controller.js
@@ -3,7 +3,6 @@
 let
 	async = require('async'),
 	crypto = require('crypto'),
-	nodemailer = require('nodemailer'),
 	path = require('path'),
 
 	deps = require(path.resolve('./src/server/dependencies.js')),
@@ -11,28 +10,14 @@ let
 	config = deps.config,
 	errorHandler = deps.errorHandler,
 	logger = deps.logger,
+	emailService = deps.emailService,
 
 	User = dbs.admin.model('User');
-
-
-// Initialize the mailer if it has been configured
-let smtpTransport;
-if (null != config.mailer) {
-	smtpTransport = nodemailer.createTransport(config.mailer.options);
-}
-
 
 /**
  * Forgot for reset password (forgot POST)
  */
 exports.forgot = (req, res, next) => {
-
-	// Make sure that the mailer is configured
-	if(null == smtpTransport) {
-		let error = { message: 'Email not configured on server.'};
-		logger.warn({req: req, error: error}, error.message);
-		return res.status(500).json(error);
-	}
 
 	// Make sure there is a username
 	if(null == req.body.username) {
@@ -102,17 +87,16 @@ exports.forgot = (req, res, next) => {
 				html: emailHTML
 			};
 
-			smtpTransport.sendMail(mailOptions, (error) => {
-				if (null == error) {
-					logger.debug('Sent email to: %s', user.email);
-					res.json('An email has been sent to ' + user.email + ' with further instructions.');
-				} else {
+			emailService.sendMail(mailOptions)
+				.then((result) => {
+					logger.debug(`Sent email to: ${user.email}`);
+					res.json(`An email has been sent to ${user.email} with further instructions.`);
+					done(null);
+
+				}, (error) => {
 					logger.error({err: error, req: req}, 'Failure sending email.');
 					return res.status(400).json({ message: 'Failure sending email.' });
-				}
-
-				done(error);
-			});
+				});
 		}
 	], (error) => {
 		if (error) return next(error);
@@ -146,13 +130,6 @@ exports.reset = (req, res, next) => {
 
 	// Init Variables
 	let password = req.body.password;
-
-	// Make sure that the mailer is configured
-	if(null == smtpTransport) {
-		let error = { message: 'Email not configured on server.'};
-		logger.warn({req: req, error: error}, error.message);
-		return res.status(500).json(error);
-	}
 
 	// Make sure there is a username
 	if(null == password) {
@@ -219,9 +196,13 @@ exports.reset = (req, res, next) => {
 				html: emailHTML
 			};
 
-			smtpTransport.sendMail(mailOptions, (error) => {
-				done(error, 'done');
-			});
+			emailService.sendMail(mailOptions)
+				.then((result) => {
+					done(null);
+
+				}, (error) => {
+					logger.error({err: error, req: req}, 'Failure sending email.');
+				});
 		}
 	], (error) => {
 		if (error) return next(error);

--- a/src/server/app/util/services/email.server.service.js
+++ b/src/server/app/util/services/email.server.service.js
@@ -1,0 +1,75 @@
+'use strict';
+
+let path = require('path'),
+	q = require('q'),
+	nodemailer = require('nodemailer'),
+	deps = require(path.resolve('./src/server/dependencies.js')),
+	config = deps.config,
+	logger = deps.logger;
+
+// Initialize the mailer if it has been configured
+let smtpTransport;
+if (config.mailer) {
+	smtpTransport = nodemailer.createTransport(config.mailer.options);
+}
+
+/**
+ * Detects issues with mailOptions
+ * returns an array of fields missing from mailOptions
+ */
+function getMissingMailOptions(mailOptions) {
+	let requiredOptions = [
+		'to',
+		'from',
+		'subject',
+		'html'
+	];
+
+	let missingOptions = [];
+
+	requiredOptions.forEach((option) => {
+		if (!mailOptions[option]) {
+			missingOptions.push(option);
+		}
+	});
+
+	return missingOptions;
+}
+
+module.exports.getMissingMailOptions = getMissingMailOptions;
+
+module.exports.sendMail = (mailOptions) => {
+	let defer = q.defer();
+
+	// Make sure that the mailer is configured
+	if (!smtpTransport) {
+		defer.reject({ message: 'Email server is not configured' });
+		return defer.promise;
+	}
+
+	// Make sure mailOptions are specified
+	if (!mailOptions) {
+		defer.reject({ message: 'No email options specified' });
+		return defer.promise;
+	}
+
+	// Make sure all the required mailOptions are defined
+	let missingOptions = getMissingMailOptions(mailOptions);
+	if (missingOptions.length > 0) {
+		defer.reject({ message: `The following required values were not specified in mailOptions: ${missingOptions.join(', ')}`});
+		return defer.promise;
+	}
+
+	smtpTransport.sendMail(mailOptions, (error) => {
+		if (!error) {
+			logger.debug(`Sent email to: ${mailOptions.to}`);
+			defer.resolve(mailOptions);
+		}
+		else {
+			logger.error('Failure sending email.');
+			defer.reject(error);
+		}
+	});
+
+	return defer.promise;
+};

--- a/src/server/app/util/services/email.server.service.spec.js
+++ b/src/server/app/util/services/email.server.service.spec.js
@@ -1,0 +1,86 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+let should = require('should'),
+	path = require('path'),
+	deps = require(path.resolve('./src/server/dependencies.js')),
+	emailService = deps.emailService;
+
+/**
+ * Globals
+ */
+
+/**
+ * Unit tests
+ */
+describe('Email Service:', () => {
+
+	describe('getMissingMailOptions:', () => {
+
+		it('should find required missing fields', () => {
+			let missing = emailService.getMissingMailOptions({});
+			missing.length.should.equal(4);
+			missing[0].should.equal('to');
+			missing[1].should.equal('from');
+			missing[2].should.equal('subject');
+			missing[3].should.equal('html');
+
+			missing = emailService.getMissingMailOptions({to: null});
+			missing.length.should.equal(4);
+			missing[0].should.equal('to');
+			missing[1].should.equal('from');
+			missing[2].should.equal('subject');
+			missing[3].should.equal('html');
+
+			missing = emailService.getMissingMailOptions({to: undefined});
+			missing.length.should.equal(4);
+			missing[0].should.equal('to');
+			missing[1].should.equal('from');
+			missing[2].should.equal('subject');
+			missing[3].should.equal('html');
+
+			missing = emailService.getMissingMailOptions({to: ''});
+			missing.length.should.equal(4);
+			missing[0].should.equal('to');
+			missing[1].should.equal('from');
+			missing[2].should.equal('subject');
+			missing[3].should.equal('html');
+
+			missing = emailService.getMissingMailOptions({to: null, from: '', html: null});
+			missing.length.should.equal(4);
+			missing[0].should.equal('to');
+			missing[1].should.equal('from');
+			missing[2].should.equal('subject');
+			missing[3].should.equal('html');
+
+			missing = emailService.getMissingMailOptions({to: 'recipient', from: '', html: null});
+			missing.length.should.equal(3);
+			missing[0].should.equal('from');
+			missing[1].should.equal('subject');
+			missing[2].should.equal('html');
+
+			missing = emailService.getMissingMailOptions({to: 'recipient'});
+			missing.length.should.equal(3);
+			missing[0].should.equal('from');
+			missing[1].should.equal('subject');
+			missing[2].should.equal('html');
+
+			missing = emailService.getMissingMailOptions({from: 'sender'});
+			missing.length.should.equal(3);
+			missing[0].should.equal('to');
+			missing[1].should.equal('subject');
+			missing[2].should.equal('html');
+
+			missing = emailService.getMissingMailOptions({to: 'recipient', from: 'sender', html: 'html'});
+			missing.length.should.equal(1);
+			missing[0].should.equal('subject');
+
+			missing = emailService.getMissingMailOptions({to: 'recipient', from: 'sender', html: 'html', subject: 'subject'});
+			missing.length.should.equal(0);
+		});
+
+	});
+
+});

--- a/src/server/dependencies.js
+++ b/src/server/dependencies.js
@@ -28,3 +28,4 @@ module.exports.utilService   = require(path.resolve('./src/server/app/util/servi
 module.exports.schemaService = require(path.resolve('./src/server/app/util/services/schema.server.service.js'));
 module.exports.csvStream     = require(path.resolve('./src/server/app/util/services/csv-stream.server.service.js'));
 module.exports.delayedStream = require(path.resolve('./src/server/app/util/services/delayed-stream.server.service.js'));
+module.exports.emailService  = require(path.resolve('./src/server/app/util/services/email.server.service.js'));


### PR DESCRIPTION
Was adding more emailing on my project, so I decided it made sense to add a reusable email service instead of implementing it each time you want to send an email.  Also updated nodemailer npm module to latest version.

If you would like to verify:

- Add mailer config to your development.js config file:
```
mailer: {
	from: '<your email address>',
	options: {
		service: 'gmail',
		auth: {
			user: '<your email address>',
			pass: '<your email password>'
		}
	}
}
```
- Run npm install to update nodemailer
- Run the app
- Use forgot password and see if you receive the email
  - I had to enable access for less secure apps through gmail to get this to work: https://www.google.com/settings/u/1/security/lesssecureapps.  Otherwise I was getting an invalid login error.  I just enabled this to do the testing and disabled afterwards.  Or you can use XOAuth2 with nodemailer to avoid enabling this: http://stackoverflow.com/a/19879741/3294324