### PR TITLE
Adding an optional flag to disable the call to resolveTeamNames

### DIFF
--- a/src/client/app/teams/list-team-members.component.ts
+++ b/src/client/app/teams/list-team-members.component.ts
@@ -119,7 +119,7 @@ export class ListTeamMembersComponent {
 	};
 
 	private getTeamMembers() {
-		this.teamsService.searchMembers(this.teamId, this.team, null, null, this.pagingOptions)
+		this.teamsService.searchMembers(this.teamId, this.team, null, null, this.pagingOptions, false)
 			.subscribe((result: any) => {
 				if (null != result && null != result.elements && result.elements.length > 0) {
 					this.teamMembers = result.elements;

--- a/src/client/app/teams/teams.service.ts
+++ b/src/client/app/teams/teams.service.ts
@@ -65,14 +65,16 @@ export class TeamsService {
 		return this.asyHttp.get(new HttpOptions(`team/${teamId}`, () => {}));
 	}
 
-	searchMembers(teamId: string, team: Team, query: any, search: any, paging: PagingOptions): Observable<any> {
+	searchMembers(teamId: string, team: Team, query: any, search: any, paging: PagingOptions, resolveTeamNames: boolean = true): Observable<any> {
 		return Observable.create((observer: any) => {
 			this.asyHttp.post(new HttpOptions(`team/${teamId}/members?${this.asyHttp.urlEncode(paging.toObj())}`, () => {}, { s: search , q: query }))
 				.subscribe(
 					(results: any) => {
 						if (null != results && _.isArray(results.elements)) {
 							results.elements = results.elements.map((element: any) => new TeamMember().setFromTeamMemberModel(team, element));
-							this.resolveTeamNames(results.elements);
+							if (resolveTeamNames) {
+								this.resolveTeamNames(results.elements);
+							}
 						}
 						observer.next(results);
 					},


### PR DESCRIPTION
When team members are loaded this gives the ability to disable the additional loading of everyone one of each team member's other teams.