### PR TITLE
Update development config template for url information

### DIFF
--- a/config/env/development.template.js
+++ b/config/env/development.template.js
@@ -17,8 +17,13 @@ module.exports = {
 
 	// Basic title and instance name
 	app: {
-		title: 'MEAN2 UI Development Settings)',
-		instanceName: 'mean2ui'
+		title: 'MEAN2 UI (Development Settings)',
+		instanceName: 'mean2ui',
+		url: {
+			protocol: 'http',
+			host: 'localhost',
+			port: 3000
+		}
 	},
 
 	// Header/footer


### PR DESCRIPTION
The app config settings changed in Asymmetrik/mean2-starter#77 to include a url key used for creating url information for mailers. This change results in livereload not working in local development unless developers add the app.url information to config/env/development.js.

To assist developers in having the proper setting, this adds the default settings to the config/env/development.template.js.