### PR TITLE
fixed liveReload url

### DIFF
--- a/src/server/app/core/views/layouts/main.server.view.html
+++ b/src/server/app/core/views/layouts/main.server.view.html
@@ -67,7 +67,7 @@
 
 	{{#if liveReload}}
 	<!--Livereload script rendered -->
-	<script type="text/javascript" src="{{host}}:{{liveReload.port}}/livereload.js"></script>
+	<script type="text/javascript" src="{{liveReloadScript}}"></script>
 	{{/if}}
 
 </body>

--- a/src/server/lib/express.js
+++ b/src/server/lib/express.js
@@ -38,6 +38,9 @@ function initLocalVariables(app) {
 	// Development
 	app.locals.developmentMode = config.mode === 'development';
 	app.locals.liveReload = config.liveReload;
+	if (config.liveReload) {
+		app.locals.liveReloadScript = `${config.app.baseUrlWithoutPort}:${config.liveReload.port}/livereload.js`;
+	}
 
 	// Passing the request url to environment locals
 	app.use(function (req, res, next) {


### PR DESCRIPTION
The liveReload URL was being created using a reference in the template to "host", which was apparently referencing the request host, so it included the protocol, baseUrl, and port and was generating an invalid reference to the liveReload script. I fixed it by explicitly setting a liveReloadUrl created from the baseUrlWithoutPort.