### PR TITLE
Load source maps for @asymmetrik packages.

### DIFF
--- a/config/build/webpack.conf.js
+++ b/config/build/webpack.conf.js
@@ -135,6 +135,14 @@ module.exports = (mode) => {
 
 	};
 
+	if (develop) {
+		wpConfig.module.loaders.push({
+			test: /node_modules\/@asymmetrik.*\.js$/,
+			loader: 'source-map-loader',
+			enforce: 'pre'
+		});
+	}
+
 
 	/**
 	 * Webpack plugins

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
 		"url-loader": "0.5",
 		"webpack-dev-middleware": "1.8",
 		"webpack-hot-middleware": "2.13",
+		"source-map-loader": "0.1",
 
 		"typescript": "2.1",
 		"ts-helpers": "1.1",


### PR DESCRIPTION
Recent changes to @asymmetrik/angular2-sentio and @asymmetrik/angular2-leaflet have those packages now publish as js bundles instead of as typescript sourcecode.

This change enables mean2-starter to continue debugging those packages when brought into mean2-starter.