### PR TITLE
Reduce test information clutter during tdd.

### DIFF
--- a/config/build/karma/karma.conf.js
+++ b/config/build/karma/karma.conf.js
@@ -51,6 +51,10 @@ module.exports = function(config) {
 		// available reporters: https://npmjs.org/browse/keyword/karma-reporter
 		reporters: karmaReporters,
 
+		mochaReporter: {
+			output: 'autowatch'
+		},
+
 		coverageReporter: {
 			type: 'in-memory'
 		},


### PR DESCRIPTION
Using the autowatch output setting for karma-mocha-reporter should cut down on the amount of logging output during development while `gulp test` or `gulp test-client` is running. After the first test run, only errors and summary information (how many tests passed, failed, or were skipped) should be output to console. This should help when scanning for error log statements or failed tests while during tdd.

Should have no impact on the ci tests as the first run of each karma test is the same output as before.