### PR TITLE
Test multidatabase configs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
 		"mocha": "3.1",
 		"mochawesome": "1.5",
 		"should": "11.1",
+		"proxyquire": "1.7",
 
 		"karma": "1.3.0",
 		"karma-coverage": "1.1.1",

--- a/src/server/lib/mongoose.spec.js
+++ b/src/server/lib/mongoose.spec.js
@@ -1,0 +1,97 @@
+const should = require('should');
+const proxyquire = require('proxyquire');
+const path = require('path');
+
+function createSubjectUnderTest(databases) {
+	const stubConfig = {
+		db: databases,
+		files: {
+			server: {
+				models: []
+			}
+		},
+		'@noCallThru': true
+	};
+
+	const stubs = {};
+	const configPath = path.resolve('./src/server/config.js');
+	stubs[configPath] = stubConfig;
+	return proxyquire('./mongoose.js', stubs);
+}
+
+describe('Mongoose', () => {
+
+	const originalMongooseLib = require('./mongoose');
+
+	before(() => {
+		return originalMongooseLib.disconnect();
+	});
+
+	after(() => {
+		return originalMongooseLib.connect();
+	});
+
+	describe('when only given admin database', () => {
+
+		let mongooseLib;
+
+		const adminDatabaseName = 'mean2-test-mongoose-admin';
+
+		beforeEach(() => {
+			mongooseLib = createSubjectUnderTest({
+				admin: `mongodb://localhost/${adminDatabaseName}`
+			});
+		});
+
+		afterEach(() => {
+			return mongooseLib.disconnect();
+		});
+
+		it('connects to admin database by default', () => {
+			return mongooseLib.connect().then((dbs) => {
+				dbs.should.have.property('admin');
+				dbs.admin.should.have.property('connection');
+				dbs.admin.connection.name.should.eql(adminDatabaseName);
+				dbs.admin.connection.readyState.should.eql(1);
+			});
+		});
+	});
+
+	describe('when given multiple databases', () => {
+		let mongooseLib;
+		const adminDatabaseName = 'mean-test-mongoose-admin';
+		const otherDatabaseName = 'mean-test-mongoose-other';
+
+		beforeEach(() => {
+			mongooseLib = createSubjectUnderTest({
+				admin: `mongodb://localhost/${adminDatabaseName}`,
+				other: `mongodb://localhost/${otherDatabaseName}`
+			});
+		});
+
+		afterEach(() => {
+			return mongooseLib.disconnect();
+		});
+
+		it('connects to admin database by default', () => {
+			return mongooseLib.connect().then((dbs) => {
+				dbs.should.have.property('admin');
+				dbs.admin.should.have.property('connection');
+				dbs.admin.connection.name.should.eql(adminDatabaseName);
+				dbs.admin.connection.readyState.should.eql(1);
+			});
+		});
+
+		it('connects to other databases', () => {
+			return mongooseLib.connect().then((dbs) => {
+				dbs.should.have.property('other');
+				dbs.other.name.should.eql(otherDatabaseName);
+				dbs.other.readyState.should.eql(1);
+			});
+		});
+
+
+	});
+
+
+});


### PR DESCRIPTION
Mongoose's API does not document the use of a callback function with Mongoose#createConnection. The callback works due to the createConnection passing the arguments passed in to Connection#open, which does accept a callback.

Since the API does not document this usage, this test case should provide a canery in case the behavior changes in the future.