### PR TITLE
Updating util service to handle more edge cases and test coverage

### DIFF
--- a/src/server/app/util/services/util.server.service.js
+++ b/src/server/app/util/services/util.server.service.js
@@ -145,19 +145,17 @@ module.exports.dateParse = function (date) {
 
 /**
  * Get the limit provided by the user, if there is one.
- * Limit has to be at least 1 and no more than 100.
+ * Limit has to be at least 1 and no more than 100, with
+ * a default value of 20.
  *
  * @param queryParams
- * @param maxSize (optional)
+ * @param maxSize (optional) default: 100
  * @returns {number}
  */
 module.exports.getLimit = function (queryParams, maxSize) {
-	let max = maxSize || 100;
-	let limit = Math.floor(queryParams.size);
-	if (null == limit || isNaN(limit)) {
-		limit = 20;
-	}
-	return Math.max(1, Math.min(max, limit));
+	const max = maxSize || 100;
+	const limit = _.get(queryParams, 'size', 20);
+	return isNaN(limit) ? 20 : Math.max(1, Math.min(max, Math.floor(limit)));
 };
 
 /**
@@ -166,8 +164,8 @@ module.exports.getLimit = function (queryParams, maxSize) {
  * @returns {number}
  */
 module.exports.getPage = function (queryParams) {
-	let page = queryParams.page || 0;
-	return Math.max(0, page);
+	const page = _.get(queryParams, 'page', 0);
+	return isNaN(page) ? 0 : Math.max(0, page);
 };
 
 /**

--- a/src/server/app/util/services/util.server.service.spec.js
+++ b/src/server/app/util/services/util.server.service.spec.js
@@ -90,4 +90,145 @@ describe('Utils:', () => {
 
 	});
 
+	describe('getPage:', () => {
+		[{
+			input: null,
+			expected: 0,
+			name: 'should handle null values with default 0'
+		}, {
+			input: 6,
+			expected: 0,
+			name: 'should handle number inputs with default 0'
+		}, {
+			input: 'test',
+			expected: 0,
+			name: 'should handle string inputs with default 0'
+		}, {
+			input: true,
+			expected: 0,
+			name: 'should handle boolean inputs with default 0'
+		}, {
+			input: { limit: 50 },
+			expected: 0,
+			name: 'should handle empty values with default 0'
+		}, {
+			input: { page: -5 },
+			expected: 0,
+			name: 'should return 0 for negative values'
+		}, {
+			input: { page: 1 },
+			expected: 1,
+			name: 'should return value for positive input'
+		}, {
+			input: { page: 'first' },
+			expected: 0,
+			name: 'should return default value 0 for string'
+		}, {
+			input: { page: 10000000 },
+			expected: 10000000,
+			name: 'should return large, positive input'
+		}].forEach((test) => {
+			it(test.name, () => {
+				const actual = util.getPage(test.input);
+				should(actual).equal(test.expected);
+			});
+		});
+	});
+
+	describe('getLimit:', () => {
+
+		const defaultLimit = 20, defaultMax = 100;
+
+		[{
+			inputQueryParams: null,
+			inputMaxSize: null,
+			expected: defaultLimit,
+			name: 'should handle null values with default'
+		}, {
+			inputQueryParams: {},
+			inputMaxSize: null,
+			expected: defaultLimit,
+			name: 'should handle empty values with default'
+		}, {
+			inputQueryParams: { size: -5 },
+			inputMaxSize: null,
+			expected: 1,
+			name: 'should return 1 for negative values'
+		}, {
+			inputQueryParams: { size: 5 },
+			inputMaxSize: null,
+			expected: 5,
+			name: 'should return value for positive input'
+		}, {
+			inputQueryParams: { size: 'twenty' },
+			inputMaxSize: null,
+			expected: defaultLimit,
+			name: 'should return default for string'
+		}, {
+			inputQueryParams: { size: 10000000 },
+			inputMaxSize: null,
+			expected: defaultMax,
+			name: 'should cap limit to default max'
+		}, {
+			inputQueryParams: { size: 10000000 },
+			inputMaxSize: 50,
+			expected: 50,
+			name: 'should cap limit to input max'
+		}].forEach((test) => {
+			it(test.name, () => {
+				const actual = util.getLimit(test.inputQueryParams, test.inputMaxSize);
+				should(actual).equal(test.expected);
+			});
+		});
+	});
+
+	describe('contains:', () => {
+		[{
+			inputArray: [1, 2, 3],
+			inputElement: 2,
+			expected: true,
+			name: 'should return true for number in array'
+		}, {
+			inputArray: [{id:1}, {id:2}, {id:3}],
+			inputElement: {id:2},
+			expected: true,
+			name: 'should return true for object with same values'
+		}, {
+			inputArray: [{id:1}, {id:2}, {id:3}],
+			inputElement: {id:2, name:'Test'},
+			expected: false,
+			name: 'should return false for object with additional attributes'
+		}, {
+			inputArray: [false, false, false],
+			inputElement: false,
+			expected: true,
+			name: 'should return true for boolean in array'
+		}, {
+			inputArray: [true, false],
+			inputElement: true,
+			expected: true,
+			name: 'should return true for boolean in array'
+		}, {
+			inputArray: [true, true],
+			inputElement: false,
+			expected: false,
+			name: 'should return false for boolean not in array'
+		}, {
+			inputArray: ['test', 'it', { id: 3 }],
+			inputElement: 'it',
+			expected: true,
+			name: 'should return true for string in array'
+		}, {
+			inputArray: ['testing', 'it out', 45, false, { id: 5 }],
+			inputElement: true,
+			expected: false,
+			name: 'should return false for boolean not in array'
+		}].forEach((test) => {
+			it(test.name, () => {
+				const actual = util.contains(test.inputArray, test.inputElement);
+				should(actual).equal(test.expected);
+			});
+		});
+	});
+
 });

--- a/src/server/app/util/services/util.server.service.spec.js
+++ b/src/server/app/util/services/util.server.service.spec.js
@@ -155,6 +155,11 @@ describe('Utils:', () => {
 			expected: 1,
 			name: 'should return 1 for negative values'
 		}, {
+			inputQueryParams: { size: 0 },
+			inputMaxSize: null,
+			expected: 1,
+			name: 'should return 1 for zero values'
+		}, {
 			inputQueryParams: { size: 5 },
 			inputMaxSize: null,
 			expected: 5,


### PR DESCRIPTION
This is a minor PR, but adds some test coverage to the `util` service. It does change some functionality in that it handles bad inputs by using default values instead of throwing JS errors. Hopefully nothing is handling errors as part of it's operation, but we should probably change that if it's doing so.