### PR TITLE
Travis-CI to Mongo 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,20 @@
 language: node_js
 node_js:
   - "6.9"
-services:
- - mongodb
 before_script:
   - npm install -g gulp
 script:
   - gulp build
   - gulp test-ci
 sudo: false
+addons:
+  apt:
+    sources:
+      - mongodb-upstart
+      - mongodb-3.0-precise
+    packages:
+      - mongodb-org-server
+      - mongodb-org-shell
 after_success:
   - npm install -g codeclimate-test-reporter lcov-result-merger template-loader-lcov-fix
   - lcov-result-merger reports/coverage/**/*/lcov.info reports/coverage/lcov-combined.info


### PR DESCRIPTION
In order to use later supported Mongo operators (such as `$search`), force Travis to Mongo 3 beyond the default 2.x.