### PR TITLE
Ensuring export filenames are set properly even if they contain spaces

### DIFF
--- a/src/client/app/shared/pageable-table/pageable-table.component.spec.ts
+++ b/src/client/app/shared/pageable-table/pageable-table.component.spec.ts
@@ -143,7 +143,7 @@ describe('PageableTable', () => {
 		fixture.detectChanges();
 
 		items.forEach((value, index) => {
-			expect(rootHTMLElement.innerText).toContain(index);
+			expect(rootHTMLElement.innerText).toContain(String(index));
 		});
 	});
 

--- a/src/server/app/util/controllers/export-config.server.controller.js
+++ b/src/server/app/util/controllers/export-config.server.controller.js
@@ -51,6 +51,7 @@ exports.requestExport = function(req, res) {
 };
 
 exports.exportCSV = function(req, res, filename, columns, data) {
+
 	if (null !== data) {
 		// Set up streaming res
 		res.set('Content-Type', 'text/csv;charset=utf-8');

--- a/src/server/app/util/controllers/export-config.server.controller.js
+++ b/src/server/app/util/controllers/export-config.server.controller.js
@@ -51,11 +51,10 @@ exports.requestExport = function(req, res) {
 };
 
 exports.exportCSV = function(req, res, filename, columns, data) {
-
 	if (null !== data) {
 		// Set up streaming res
 		res.set('Content-Type', 'text/csv;charset=utf-8');
-		res.set('Content-Disposition', 'attachment;filename=' + filename);
+		res.set('Content-Disposition', `attachment;filename="${filename}"`);
 		res.set('Transfer-Encoding', 'chunked');
 
 		// Put into stream the data object
@@ -97,7 +96,7 @@ exports.exportPlaintext = function(req, res, filename, text) {
 	if (null !== text) {
 		// Set up streaming res
 		res.set('Content-Type', 'text/plain;charset=utf-8');
-		res.set('Content-Disposition', 'attachment;filename=' + filename);
+		res.set('Content-Disposition', `attachment;filename="${filename}"`);
 		res.set('Transfer-Encoding', 'chunked');
 
 		// Put into stream the data object


### PR DESCRIPTION
This was an issue in firefox