### PR TITLE
Adding resourceChange output event emitter to manage-resource-metadata component

### DIFF
--- a/src/client/app/resources/manage-resource-metadata.component.html
+++ b/src/client/app/resources/manage-resource-metadata.component.html
@@ -3,14 +3,14 @@
 	<!-- Title -->
 	<div class="form-group row col-md-12" *ngIf="!hideTitle">
 		<label for="title">Title<span class="text-danger"><strong> *</strong></span></label>
-		<input *ngIf="!readOnly" type="text" class="form-control input-sm" id="title" name="title" [(ngModel)]="resource.title" required />
+		<input *ngIf="!readOnly" type="text" class="form-control input-sm" id="title" name="title" [ngModel]="resource.title" (ngModelChange)="updateField('title', $event)" required />
 		<div *ngIf="readOnly">{{ resource.title }}</div>
 	</div>
 
 	<!-- Owner -->
 	<div class="form-group row col-md-12">
 		<label for="owner">Owner<span class="text-danger"><strong> *</strong></span></label>
-		<select *ngIf="mode === 'create' && !readOnly" class="form-control input-sm" id="owner" name="owner" [(ngModel)]="resource.owner" (ngModelChange)="getTagOptions()">
+		<select *ngIf="mode === 'create' && !readOnly" class="form-control input-sm" id="owner" name="owner" [ngModel]="resource.owner" (ngModelChange)="updateField('owner', $event)">
 			<option *ngFor="let owner of ownerOptions" [ngValue]="owner">{{ owner.name }}</option>
 		</select>
 		<div *ngIf="mode !== 'create' || readOnly">
@@ -34,7 +34,7 @@
 	<!-- Description -->
 	<div class="form-group row col-md-12" *ngIf="!hideDescription && !readOnly">
 		<label for="description">Description</label>
-		<textarea rows="3" class="form-control input-sm" id="description" name="description" [(ngModel)]="resource.description"></textarea>
+		<textarea rows="3" class="form-control input-sm" id="description" name="description" [ngModel]="resource.description" (ngModelChange)="updateField('description', $event)"></textarea>
 	</div>
 
 	<div class="form-group row col-md-12" *ngIf="!hideDescription && readOnly && haveDescription()">

--- a/src/client/app/resources/manage-resource-metadata.component.ts
+++ b/src/client/app/resources/manage-resource-metadata.component.ts
@@ -29,6 +29,8 @@ export class ManageResourceMetadataComponent {
 
 	@Output() alertError = new EventEmitter();
 
+	@Output() resourceChange = new EventEmitter();
+
 	ownerOptions: Owner[] = [];
 
 	tagOptions: Tag[] = [];
@@ -54,6 +56,7 @@ export class ManageResourceMetadataComponent {
 					// Default to the first team in the list
 					if (this.mode === 'create') {
 						this.resource.owner = this.ownerOptions[0];
+						this.resourceChange.emit(this.resource);
 					}
 
 					this.getTagOptions();
@@ -95,10 +98,20 @@ export class ManageResourceMetadataComponent {
 		return this.resource.description != null && !_.isEmpty(this.resource.description.trim());
 	}
 
-	private updateTags(event: any) {
+	updateTags(event: any) {
 		if (event.hasOwnProperty('items')) {
 			this.resource.tags = event.items;
 			this.processTags();
+			this.resourceChange.emit(this.resource);
+		}
+	}
+
+	updateField(field: string, value: any) {
+		this.resource[field] = value;
+		this.resourceChange.emit(this.resource);
+
+		if (field === 'owner') {
+			this.getTagOptions();
 		}
 	}
 }

--- a/src/client/app/shared/pageable-table/pageable-table.component.spec.ts
+++ b/src/client/app/shared/pageable-table/pageable-table.component.spec.ts
@@ -143,7 +143,7 @@ describe('PageableTable', () => {
 		fixture.detectChanges();
 
 		items.forEach((value, index) => {
-			expect(rootHTMLElement.innerText).toContain(index);
+			expect(rootHTMLElement.innerText).toContain(String(index));
 		});
 	});
 


### PR DESCRIPTION
This is useful in case any parent components want to respond to changes. Also more robust to support two-way data binding in case manage-resource-metadata ever updates what 'resource' refers to.