### PR TITLE
Adding proper overflow and styling to tag resources

### DIFF
--- a/src/client/app/teams/tags/list-tags.component.html
+++ b/src/client/app/teams/tags/list-tags.component.html
@@ -66,13 +66,12 @@
 					No resources
 				</div>
 				<div *ngIf="tag?.resources?.length > 0">
-					<span class="label label-gray hide-overflow"
-							style="max-width:400px;"
-							*ngFor="let resource of tag.resources">
+					<span class="resource-name label label-gray hide-overflow"
+						  *ngFor="let resource of tag.resources">
 						{{resource.title}}
 					</span>
-					<span class="label label-gray hide-overflow"
-							*ngIf="tag?.numResources > maxResourcesShownInline">
+					<span class="resource-name controls hide-overflow"
+						  *ngIf="tag?.numResources > maxResourcesShownInline">
 						...and {{tag?.numResources-maxResourcesShownInline}} more
 					</span>
 				</div>

--- a/src/client/app/teams/tags/tags.scss
+++ b/src/client/app/teams/tags/tags.scss
@@ -4,3 +4,9 @@
 	display: inline-block;
 	max-width: 100px;
 }
+
+.resource-name {
+	display: inline-block;
+	margin: 3px;
+	max-width: 200px;
+}


### PR DESCRIPTION
Example of what this will look like:

![screen shot 2017-03-27 at 5 35 48 pm](https://cloud.githubusercontent.com/assets/8506603/24379436/1a3f980c-1315-11e7-9c04-7c73661227ad.png)
