### PR TITLE
Adding yarn.lock file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ nb-configuration.xml
 
 # Node
 node_modules/
+yarn.lock
 
 # Common
 bin/


### PR DESCRIPTION
If you are using yarn to install npm modules, git ignore the yarn.lock file