### PR TITLE
[A-280] Ensuring interface-url HTTP header properly encoded/decoded

### DIFF
--- a/src/client/app/shared/asy-http.service.ts
+++ b/src/client/app/shared/asy-http.service.ts
@@ -194,7 +194,9 @@ export class AsyHttp {
 	}
 
 	private getUriEncodedPath() {
-		return encodeURI(this.location.path());
+		let path = this.location.path();
+		let alreadyEncoded = decodeURI(path) !== path;
+		return alreadyEncoded ? path : encodeURI(this.location.path());
 	}
 
 }

--- a/src/client/app/shared/asy-http.service.ts
+++ b/src/client/app/shared/asy-http.service.ts
@@ -39,7 +39,7 @@ export class AsyHttp {
 
 	get(opts: HttpOptions) {
 		let headers = new Headers({
-			'Interface-URL': this.location.path()
+			'Interface-URL': this.getUriEncodedPath()
 		});
 
 		let observable = this._http.get(opts.url, {search: opts.urlParams, headers: headers} )
@@ -63,7 +63,7 @@ export class AsyHttp {
 	post(opts: HttpOptions) {
 		let headers = new Headers({
 			'Content-Type': 'application/json',
-			'Interface-URL': this.location.path()
+			'Interface-URL': this.getUriEncodedPath()
 		});
 
 		let observable = this._http.post(opts.url, JSON.stringify(opts.data), {
@@ -87,7 +87,7 @@ export class AsyHttp {
 	put(opts: HttpOptions) {
 		let headers = new Headers({
 			'Content-Type': 'application/json',
-			'Interface-URL': this.location.path()
+			'Interface-URL': this.getUriEncodedPath()
 		});
 
 		let observable = this._http.put(opts.url, JSON.stringify(opts.data), {
@@ -110,7 +110,7 @@ export class AsyHttp {
 
 	delete(opts: HttpOptions) {
 		let headers = new Headers({
-			'Interface-URL': this.location.path()
+			'Interface-URL': this.getUriEncodedPath()
 		});
 
 		let observable = this._http.delete(opts.url, { headers: headers})
@@ -191,6 +191,10 @@ export class AsyHttp {
 
 	private hasContent(res: Response) {
 		return (res.status !== 204 && (<string> res.text()).length > 0);
+	}
+
+	private getUriEncodedPath() {
+		return encodeURI(this.location.path());
 	}
 
 }

--- a/src/server/app/audit/services/audit.server.service.js
+++ b/src/server/app/audit/services/audit.server.service.js
@@ -14,7 +14,10 @@ module.exports.audit = function(message, eventType, eventAction, eventActor, eve
 	let utilService = deps.utilService;
 
 	// Extract additional metadata to audit
-	let interfaceUrl = decodeURI(utilService.getHeaderField(eventMetadata, 'interface-url'));
+	let interfaceUrl = utilService.getHeaderField(eventMetadata, 'interface-url');
+	if (interfaceUrl != null) {
+		interfaceUrl = decodeURI(interfaceUrl);
+	}
 	let userAgentObj = utilService.getUserAgentFromHeader(eventMetadata);
 
 	// Send to Mongo

--- a/src/server/app/audit/services/audit.server.service.js
+++ b/src/server/app/audit/services/audit.server.service.js
@@ -14,7 +14,7 @@ module.exports.audit = function(message, eventType, eventAction, eventActor, eve
 	let utilService = deps.utilService;
 
 	// Extract additional metadata to audit
-	let interfaceUrl = utilService.getHeaderField(eventMetadata, 'interface-url');
+	let interfaceUrl = decodeURI(utilService.getHeaderField(eventMetadata, 'interface-url'));
 	let userAgentObj = utilService.getUserAgentFromHeader(eventMetadata);
 
 	// Send to Mongo

--- a/src/server/app/util/services/util.server.service.js
+++ b/src/server/app/util/services/util.server.service.js
@@ -176,7 +176,7 @@ module.exports.getPage = function (queryParams) {
  * Extract given field from request header
  */
 module.exports.getHeaderField = function (header, fieldName) {
-	return (null == header || null == header[fieldName]) ? null : header[fieldName];
+	return (null == header || null == header[fieldName]) ? null : decodeURI(header[fieldName]);
 };
 
 /**

--- a/src/server/app/util/services/util.server.service.js
+++ b/src/server/app/util/services/util.server.service.js
@@ -176,7 +176,7 @@ module.exports.getPage = function (queryParams) {
  * Extract given field from request header
  */
 module.exports.getHeaderField = function (header, fieldName) {
-	return (null == header || null == header[fieldName]) ? null : decodeURI(header[fieldName]);
+	return (null == header || null == header[fieldName]) ? null : header[fieldName];
 };
 
 /**


### PR DESCRIPTION
interface-url is set to the application's current URL, which can include characters that need to be encoded before being sent in an HTTP header. older Firefox versions (e.g. FF 31) didn't automatically encode the URL, which was causing HTTP requests from certain client routes to fail. Added logic to encode in the http client service and decode the header on the server.