### PR TITLE
Adding access-control headers to the webpackDevServer configuration

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -82,6 +82,7 @@ gulp.task('webpack-dev-server', (done) => {
 
 	new webpackDevServer(compiler, {
 		publicPath: `${config.app.url.protocol}://${config.app.url.host}:${config.devPorts.webpack}/dev/`,
+		headers: { 'Access-Control-Allow-Origin': `${config.app.url.protocol}://${config.app.url.host}:${config.app.url.port}`, 'Access-Control-Allow-Credentials': 'true' },
 		stats: {
 			chunks: false,
 			children: false,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -82,7 +82,7 @@ gulp.task('webpack-dev-server', (done) => {
 
 	new webpackDevServer(compiler, {
 		publicPath: `${config.app.url.protocol}://${config.app.url.host}:${config.devPorts.webpack}/dev/`,
-		headers: { 'Access-Control-Allow-Origin': `${config.app.url.protocol}://${config.app.url.host}:${config.app.url.port}`, 'Access-Control-Allow-Credentials': 'true' },
+		headers: { 'Access-Control-Allow-Origin': '*' },
 		stats: {
 			chunks: false,
 			children: false,


### PR DESCRIPTION
I was seeing this error in both Chrome and Firefox

> Access to Font at 'http://localhost:9000/dev/af7ae505a9eed503f8b8e6982036873e.woff2' from origin 'http://localhost:3000' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'http://localhost:3000' is therefore not allowed access.

Because of that error I was not able to view the font awesome icons in mean2 starter.

The fix was to add headers  to the webpackDevServer configuration:

> { 'Access-Control-Allow-Origin': \`${config.app.url.protocol}://${config.app.url.host}:${config.app.url.port}\`, 'Access-Control-Allow-Credentials': 'true' }
