### PR TITLE
Update travis.yml for trusty environment.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,15 @@
 language: node_js
+dist: trusty
 node_js:
   - "6.9"
+services:
+  - mongodb
 before_script:
   - npm install -g gulp
 script:
   - gulp build
   - gulp test-ci
 sudo: false
-addons:
-  apt:
-    sources:
-      - mongodb-upstart
-      - mongodb-3.0-precise
-    packages:
-      - mongodb-org-server
-      - mongodb-org-shell
 after_success:
   - npm install -g codeclimate-test-reporter lcov-result-merger template-loader-lcov-fix
   - lcov-result-merger reports/coverage/**/*/lcov.info reports/coverage/lcov-combined.info


### PR DESCRIPTION
Travis-CI recently updated their default environments to trusty and updated MongoDB services on trusty to use Mongo 3.x be default.

To work on trusty, we need to remove the packages needed for precise and can revert back to using the default mongo service.

Addresses Asymmetrik/mean2-starter issue #141 

See https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming and https://github.com/travis-ci/travis-ci/issues/3694